### PR TITLE
feat(ci): add mypy type checking gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,23 @@ jobs:
       - name: Ruff format check
         run: ruff format --check src/ tests/
 
+  typecheck:
+    name: Type check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run mypy
+        run: mypy src/
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dev = [
     "ruff>=0.6",
     "pip-audit>=2.7",
     "bandit>=1.7",
+    "mypy>=1.11",
 ]
 gpu = [
     "torch>=2.4",
@@ -51,6 +52,17 @@ select = ["E", "F", "I", "N", "W", "UP"]
 "src/data/build_demo_case_csv.py" = ["E501"]  # embedded SQL strings
 "src/data/load_postgres.py" = ["E501"]  # formatted output strings
 "tests/test_build_features.py" = ["E501"]  # embedded CSV test data
+
+[tool.mypy]
+python_version = "3.12"
+warn_return_any = true
+warn_unused_configs = true
+check_untyped_defs = true
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "tests.*"
+disallow_untyped_defs = false
 
 [tool.bandit]
 exclude_dirs = ["tests", ".venv"]

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -43,6 +43,8 @@ def create_app() -> FastAPI:
         try:
             from src.api.deps import pool
 
+            if pool is None:
+                raise RuntimeError("Pool not initialized")
             async with pool.connection() as conn:
                 await conn.execute("SELECT 1")
         except Exception:

--- a/src/api/deps.py
+++ b/src/api/deps.py
@@ -32,5 +32,7 @@ async def close_pool() -> None:
 
 async def get_db():
     """FastAPI dependency — yields an async connection from the pool."""
+    if pool is None:
+        raise RuntimeError("Database pool not initialized — app lifespan not started")
     async with pool.connection() as conn:
         yield conn

--- a/src/data/build_demo_case_csv.py
+++ b/src/data/build_demo_case_csv.py
@@ -433,7 +433,8 @@ def build_demo_case_csv() -> Path:
         ORDER BY 1
         """
     ).fetchall()
-    total_rows = con.execute("SELECT COUNT(*) FROM demo_case_export").fetchone()[0]
+    row = con.execute("SELECT COUNT(*) FROM demo_case_export").fetchone()
+    total_rows = row[0] if row else 0
 
     print(f"Created {output_csv}")
     print(f"Total rows: {total_rows}")

--- a/src/data/load_postgres.py
+++ b/src/data/load_postgres.py
@@ -45,8 +45,8 @@ def load_service_cases(conn: psycopg.Connection, csv_path: Path = DEMO_CSV) -> i
                 copy.write(chunk)
 
     conn.commit()
-    count = conn.execute("SELECT COUNT(*) FROM provider_service_cases").fetchone()[0]
-    return count
+    row = conn.execute("SELECT COUNT(*) FROM provider_service_cases").fetchone()
+    return row[0] if row else 0
 
 
 def load_features(conn: psycopg.Connection, parquet_path: Path = FEATURES_PARQUET) -> int:
@@ -74,8 +74,8 @@ def load_features(conn: psycopg.Connection, parquet_path: Path = FEATURES_PARQUE
             copy.write(chunk)
 
     conn.commit()
-    count = conn.execute("SELECT COUNT(*) FROM provider_features").fetchone()[0]
-    return count
+    row = conn.execute("SELECT COUNT(*) FROM provider_features").fetchone()
+    return row[0] if row else 0
 
 
 def main() -> None:
@@ -99,10 +99,12 @@ def main() -> None:
     # Quick validation
     print("\nValidation:")
     for table in ["provider_service_cases", "provider_features"]:
-        count = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+        row = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()
+        count = row[0] if row else 0
         print(f"  {table}: {count:,} rows")
 
-    if conn.execute("SELECT COUNT(*) FROM provider_features").fetchone()[0] > 0:
+    row = conn.execute("SELECT COUNT(*) FROM provider_features").fetchone()
+    if row and row[0] > 0:
         top5 = conn.execute("""
             SELECT npi, provider_name, provider_type, state,
                    max_seed_risk_score, risk_legitimacy_gap

--- a/src/pipeline/build_features.py
+++ b/src/pipeline/build_features.py
@@ -219,7 +219,7 @@ def main() -> None:
     print(f"  Unique NPIs: {df['npi'].n_unique()}")
     print(f"  Revoked providers: {df.filter(pl.col('revoked_2026') == 1).shape[0]}")
     print(f"  High-risk lines > 0: {df.filter(pl.col('n_high_risk_lines') > 0).shape[0]}")
-    print(f"  Mean service_hhi: {df['service_hhi'].mean():.4f}")
+    print(f"  Mean service_hhi: {df['service_hhi'].mean()!r}")
     print("  Null counts:")
     for col in df.columns:
         null_count = df[col].null_count()


### PR DESCRIPTION
## Summary

Closes #74

Adds mypy type checking as a parallel CI job. Fixed all 6 type errors in existing code.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | New `typecheck` job (mypy src/), parallel with lint and test |
| `pyproject.toml` | mypy config + mypy added to dev deps |
| `src/api/deps.py` | None guard on pool before `.connection()` |
| `src/api/app.py` | None guard on pool in health endpoint |
| `src/data/load_postgres.py` | `fetchone()` None guards (4 occurrences) |
| `src/data/build_demo_case_csv.py` | `fetchone()` None guard |
| `src/pipeline/build_features.py` | polars `.mean()` str-bytes-safe fix |

## Type Errors Fixed

1. **`fetchone()[0]` on nullable result** — `fetchone()` returns `tuple | None`, added guards
2. **`pool.connection()` on nullable pool** — pool is `None` before lifespan starts, added RuntimeError guard
3. **polars `.mean()` in f-string** — return type includes bytes in union, used `!r` format

## Test Plan

- [x] `mypy src/` passes clean (0 errors, 12 files checked)
- [x] `ruff check + format` still passes
- [x] `pytest` — 17 tests pass
- [ ] All CI jobs pass (lint, typecheck, test, secrets, security)