### PR TITLE
docs(sdlc): add CONTRIBUTING.md and project CLAUDE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ build/
 
 # Claude Code
 .claude/
-CLAUDE.md
 
 # Environment
 .env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,63 @@
+# CMS Fraud Detection - Claude Instructions
+
+## SDLC — MANDATORY
+
+Follow CONTRIBUTING.md for all code changes. Key rules:
+
+1. **Never commit to main.** Always: branch → PR → CI green → review → merge.
+2. **One issue at a time.** Label it `in-progress`, create branch `<type>/<N>-<desc>`.
+3. **Run CI locally before pushing:**
+   ```bash
+   ruff check src/ tests/ && ruff format --check src/ tests/
+   mypy src/
+   pytest --cov=src --cov-report=term -q
+   ```
+4. **Conventional commits:** `type(scope): description (#N)`
+5. **PR must include** `Closes #N` in body.
+6. **Self-validate (BASSPC) before presenting PR** — never skip this.
+7. **After merge:** verify issue closed, update parent epic, `git checkout main && git pull`.
+8. **Watch CI in background** — don't flood context with `gh run watch` output.
+
+## Project Overview
+
+Proactive CMS provider fraud detection with explainable AI. Identifies anomalous Medicare billing patterns using peer comparison, risk scoring, and AI-generated narratives.
+
+## Architecture
+
+- **API:** FastAPI with async psycopg pool (`src/api/`)
+- **Pipeline:** Polars-based feature engineering (`src/pipeline/`)
+- **Data:** psycopg COPY bulk loader (`src/data/`)
+- **DB:** PostgreSQL 16 on forge k3s (NodePort 30432)
+- **Schemas:** Pydantic v2 models (`src/api/schemas.py`)
+
+## Key Files
+
+| Path                             | Purpose                                 |
+| -------------------------------- | --------------------------------------- |
+| `src/api/app.py`                 | FastAPI app factory with lifespan       |
+| `src/api/deps.py`                | DB pool management, FastAPI deps        |
+| `src/api/schemas.py`             | All Pydantic request/response models    |
+| `src/pipeline/build_features.py` | Provider-level feature engineering      |
+| `src/data/load_postgres.py`      | Bulk data loader                        |
+| `tests/test_build_features.py`   | Feature pipeline tests                  |
+| `pyproject.toml`                 | Deps, ruff, mypy, bandit, pytest config |
+
+## CI Checks (all must pass on PRs)
+
+| Workflow       | Jobs                                                    |
+| -------------- | ------------------------------------------------------- |
+| `ci.yml`       | lint (ruff), typecheck (mypy), test (pytest + coverage) |
+| `secrets.yml`  | gitleaks secrets scan                                   |
+| `security.yml` | pip-audit (CVEs), bandit (SAST)                         |
+
+## Conventions
+
+- **Git:** conventional commits, present tense, `(#N)` suffix
+- **Python:** 3.12+, ruff for lint/format, mypy for types
+- **Naming:** kebab-case dirs/files, PascalCase classes, snake_case functions
+- **Risk bands:** 0-30 stable, 31-50 review, 51+ high_risk
+- **DB creds:** dev default `cms:cms_local_dev` — never use in production
+
+## Active Epics
+
+- **Epic #8:** CI/CD Pipeline — see issue for child issues and status

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,168 @@
+# Contributing to CMS Fraud Detection
+
+## Development Workflow (SDLC)
+
+Every change follows this process. No exceptions.
+
+```
+Issue → Branch → Implement → Local CI → Commit → Push → PR → CI Green → Review → Merge → Cleanup
+```
+
+### 1. Pick an Issue
+
+- Choose from the [issue backlog](https://github.com/precisesoft/cms-fraud-detection/issues)
+- Label it `in-progress`
+- One issue at a time per developer
+
+### 2. Create a Branch
+
+```bash
+git checkout main && git pull
+git checkout -b <type>/<issue-number>-<short-description>
+```
+
+Branch naming:
+| Type | When |
+|------|------|
+| `feat/` | New feature or capability |
+| `fix/` | Bug fix |
+| `docs/` | Documentation only |
+| `ci/` | CI/CD changes |
+| `refactor/` | Code restructure, no behavior change |
+| `test/` | Test additions or fixes |
+| `chore/` | Dependency updates, config changes |
+
+Examples: `feat/36-providers-endpoint`, `fix/42-null-score`, `ci/72-dependabot`
+
+### 3. Implement
+
+- Work on your branch, never on `main`
+- Keep changes focused on the issue scope
+
+### 4. Verify Locally Before Pushing
+
+Run the exact CI commands before your first push:
+
+```bash
+# Lint + format
+ruff check src/ tests/
+ruff format --check src/ tests/
+
+# Type check
+mypy src/
+
+# Tests + coverage
+pytest --cov=src --cov-report=term -q
+
+# Security (optional but recommended)
+pip-audit --skip-editable
+bandit -r src/ -c pyproject.toml
+```
+
+### 5. Commit
+
+Use conventional commits. Every commit references the issue.
+
+```
+type(scope): description (#N)
+```
+
+| Type       | Description   |
+| ---------- | ------------- |
+| `feat`     | New feature   |
+| `fix`      | Bug fix       |
+| `docs`     | Documentation |
+| `ci`       | CI/CD         |
+| `refactor` | Restructure   |
+| `test`     | Tests         |
+| `chore`    | Maintenance   |
+
+Examples:
+
+```
+feat(api): add providers endpoint (#36)
+fix(ci): skip editable package in pip-audit (#71)
+docs(sdlc): add CONTRIBUTING.md (#81)
+```
+
+Rules:
+
+- Present tense, lowercase, no period
+- Under 72 characters
+- Explain "why" not "what" in the body (if needed)
+
+### 6. Push and Create PR
+
+```bash
+git push -u origin <branch-name>
+gh pr create --title "type(scope): description" --body "Closes #N ..."
+```
+
+PR body must include:
+
+- `Closes #N` (auto-closes the issue on merge)
+- Summary of changes
+- Test plan (what was verified)
+
+### 7. CI Must Pass
+
+These checks run automatically on every PR:
+
+| Workflow | Jobs                                                     | Blocks Merge? |
+| -------- | -------------------------------------------------------- | ------------- |
+| CI       | Lint (ruff), Type check (mypy), Test (pytest + coverage) | Yes           |
+| Secrets  | gitleaks scan                                            | Yes           |
+| Security | pip-audit (dependency CVEs), bandit (SAST)               | Yes           |
+
+All checks must be green before merge.
+
+### 8. Review
+
+- Self-review your own PR before requesting review
+- At least 1 approval required (when branch protection is active)
+- Address all review comments
+
+### 9. Merge
+
+- **Squash merge** only (keeps main history clean)
+- Delete the branch after merge
+
+### 10. Cleanup
+
+After merge:
+
+- Verify the issue was auto-closed
+- Update the parent epic checklist if applicable
+- `git checkout main && git pull`
+
+## What NOT to Do
+
+- Never push directly to `main`
+- Never force push to `main`
+- Never merge without CI passing
+- Never skip the PR process for "quick fixes"
+- Never batch multiple issues into one PR
+- Never merge your own PR without at least self-review
+
+## Local Setup
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # or: . .venv/bin/activate.fish
+pip install -e ".[dev]"
+```
+
+## Project Structure
+
+```
+src/
+  api/          FastAPI app, routes, schemas
+  data/         Data loading, CSV generation
+  pipeline/     Feature engineering (Polars)
+  models/       ML models (future)
+  explainability/ SHAP explanations (future)
+tests/          pytest test suite
+.github/
+  workflows/    CI/CD pipelines
+db/             Database schema (init.sql)
+```


### PR DESCRIPTION
## Summary

Closes #81

Codifies the SDLC workflow so that every developer, AI agent, or new session follows the same process. No more tribal knowledge.

## Changes

| File | Description |
|------|-------------|
| `CONTRIBUTING.md` | Full SDLC workflow: branch naming, commit format, local CI commands, PR checklist, what not to do |
| `CLAUDE.md` | Project instructions loaded by every Claude Code session — enforces SDLC, documents architecture |
| `.gitignore` | Removed `CLAUDE.md` entry so it's committed and shared |

## How It Works

- **Human developers** read `CONTRIBUTING.md` — it's the canonical reference
- **AI agents** load `CLAUDE.md` automatically at session start — it says "follow CONTRIBUTING.md" and adds project-specific context (architecture, key files, conventions)
- **New sessions** get the SDLC rules without anyone having to explain them

## Test Plan

- [x] Local CI passes (ruff, mypy, pytest)
- [x] BASSPC self-review completed
- [ ] CI checks pass on this PR
- [ ] Verify `CLAUDE.md` is loaded in next Claude Code session