### PR TITLE
ci(deps): add Dependabot configuration for pip ecosystem (#72)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "infra"
+      - "dependencies"
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

- Add `.github/dependabot.yml` for automated dependency updates
- Configured for pip ecosystem targeting `pyproject.toml`
- Weekly schedule (Mondays), grouped minor/patch updates
- Security updates handled immediately (not batched)
- Conventional commit prefix: `chore(deps):`
- Auto-labels: `infra`, `dependencies`
- Max 5 open PRs to prevent flood

Closes #72

## Test Plan

- [x] YAML syntax validated
- [x] Local CI passes (ruff, mypy, pytest)
- [x] Config-only change — no code impact
- [ ] GitHub validates config on merge (Dependabot tab in Settings)