### PR TITLE
ci(sdlc): add PR template and branch protection rules (#14)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+## Summary
+
+<!-- What does this PR do and why? -->
+
+Closes #<!-- issue number -->
+
+## Changes
+
+<!-- Bullet list of key changes -->
+
+-
+
+## Test Plan
+
+<!-- How was this verified? -->
+
+- [ ] Local CI passes (`ruff check`, `ruff format --check`, `mypy`, `pytest`)
+- [ ] New/updated tests cover the change
+- [ ] No breaking changes (or documented below)
+
+## Screenshots
+
+<!-- If UI changes, add before/after screenshots. Delete this section otherwise. -->
+
+## Breaking Changes
+
+<!-- List any breaking changes. Delete this section if none. -->
+
+## PR Title Convention
+
+<!-- Ensure your PR title follows: type(scope): description (#N) -->
+<!-- Types: feat | fix | docs | ci | refactor | test | chore -->


### PR DESCRIPTION
## Summary

- Add `.github/pull_request_template.md` with standardized checklist (linked issue, changes, test plan, breaking changes, conventional commit guidance)
- Branch protection rules to be applied via `gh api` after merge (requires the template to exist first)

### Branch protection plan (applied post-merge):
- Require PR before merging (no direct push to main)
- Require status checks: `Lint`, `Type check`, `Test`, `Secrets scan`, `Dependency audit`, `SAST (bandit)`
- Require branches up-to-date before merge
- Require conversation resolution
- Disable force push and branch deletion

Closes #14

## Test Plan

- [x] Local CI passes (ruff, mypy, pytest)
- [x] PR template renders correctly (markdown-only file)
- [x] Config-only change — no code impact
- [ ] Branch protection verified after merge via `gh api`