### PR TITLE
ci(sdlc): add PR title conventional commit lint (#75)

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,36 @@
+name: PR Title
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches: [main]
+
+jobs:
+  lint-title:
+    name: Conventional commit check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          PATTERN='^(feat|fix|docs|style|refactor|perf|test|chore|ci|build|revert)(\(.+\))?: .{1,72}$'
+
+          if [[ "$PR_TITLE" =~ $PATTERN ]]; then
+            echo "✅ PR title is valid: $PR_TITLE"
+          else
+            echo "❌ PR title does not match conventional commit format."
+            echo ""
+            echo "Expected: type(scope): description"
+            echo ""
+            echo "  type  = feat|fix|docs|style|refactor|perf|test|chore|ci|build|revert"
+            echo "  scope = optional, e.g. (api), (ci), (pipeline)"
+            echo "  description = lowercase, no period, under 72 chars"
+            echo ""
+            echo "Examples:"
+            echo "  feat(api): add providers endpoint (#36)"
+            echo "  fix(pipeline): handle null risk scores (#42)"
+            echo "  ci(deps): add Dependabot configuration (#72)"
+            echo ""
+            echo "Got: $PR_TITLE"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

- Add `.github/workflows/pr-title.yml` that validates PR titles against the conventional commit pattern
- Regex: `^(feat|fix|docs|style|refactor|perf|test|chore|ci|build|revert)(\(.+\))?: .{1,72}$`
- Runs on PR open/edit/sync/reopen — validates PR title (not individual commits) since we squash-merge
- Clear error message with format spec and examples on failure

Closes #75

## Test Plan

- [x] Local CI passes (ruff, mypy, pytest)
- [x] This PR's own title matches the pattern (self-test)
- [ ] Workflow runs on this PR and the `Conventional commit check` job passes
- [ ] Invalid titles would fail (verified via regex logic)