### PR TITLE
docs(sdlc): add post-merge cleanup steps and update CI checks table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Follow CONTRIBUTING.md for all code changes. Key rules:
 4. **Conventional commits:** `type(scope): description (#N)`
 5. **PR must include** `Closes #N` in body.
 6. **Self-validate (BASSPC) before presenting PR** — never skip this.
-7. **After merge:** verify issue closed, update parent epic, `git checkout main && git pull`.
+7. **After merge:** verify issue closed, comment PR# on issue, update parent epic (mark CLOSED with PR#), remove `in-progress` label, `git checkout main && git pull`.
 8. **Watch CI in background** — don't flood context with `gh run watch` output.
 
 ## Project Overview
@@ -49,6 +49,8 @@ Proactive CMS provider fraud detection with explainable AI. Identifies anomalous
 | `ci.yml`       | lint (ruff), typecheck (mypy), test (pytest + coverage) |
 | `secrets.yml`  | gitleaks secrets scan                                   |
 | `security.yml` | pip-audit (CVEs), bandit (SAST)                         |
+| `pr-title.yml` | conventional commit format check                        |
+| `sbom.yml`     | CycloneDX SBOM (push to main only)                      |
 
 ## Conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,7 @@ These checks run automatically on every PR:
 | CI       | Lint (ruff), Type check (mypy), Test (pytest + coverage) | Yes           |
 | Secrets  | gitleaks scan                                            | Yes           |
 | Security | pip-audit (dependency CVEs), bandit (SAST)               | Yes           |
+| PR Title | Conventional commit format check                         | Yes           |
 
 All checks must be green before merge.
 
@@ -132,7 +133,9 @@ All checks must be green before merge.
 After merge:
 
 - Verify the issue was auto-closed
-- Update the parent epic checklist if applicable
+- Comment on the issue with the PR number (e.g., `Resolved in PR #N`)
+- Update the parent epic checklist: mark issue as CLOSED with PR number
+- Remove `in-progress` label from the issue
 - `git checkout main && git pull`
 
 ## What NOT to Do


### PR DESCRIPTION
## Summary

- Add explicit post-merge cleanup steps to CONTRIBUTING.md and CLAUDE.md:
  - Comment PR# on the issue
  - Update parent epic body (mark CLOSED with PR#)
  - Remove `in-progress` label
- Update CI checks table in both files to include `pr-title.yml` and `sbom.yml`

This was missing from the workflow and caused PRs not being linked to their issues.

## Test Plan

- [x] Local CI passes
- [x] Docs-only change — no code impact