### PR TITLE
feat(api): add on-the-fly scoring endpoint (#26)

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -36,8 +36,10 @@ def create_app() -> FastAPI:
 
     # --- Routers ---
     from src.api.routes.providers import router as providers_router
+    from src.api.routes.score import router as score_router
 
     app.include_router(providers_router, prefix="/api")
+    app.include_router(score_router, prefix="/api")
 
     # --- Health endpoint (no router needed) ---
     from src.api.schemas import HealthResponse

--- a/src/api/routes/score.py
+++ b/src/api/routes/score.py
@@ -1,0 +1,132 @@
+"""On-the-fly scoring endpoint — score a claim not yet in the database."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from psycopg import AsyncConnection
+from psycopg.rows import dict_row
+
+from src.api.deps import get_db
+from src.api.schemas import ScoreRequest, ScoreResult, Signal, risk_band_from_score
+from src.scoring.extract import FiredSignal
+from src.scoring.score import score_case
+from src.scoring.taxonomy import MIN_PEER_COUNT
+
+router = APIRouter(prefix="/score", tags=["scoring"])
+
+# ---------------------------------------------------------------------------
+# SQL
+# ---------------------------------------------------------------------------
+
+_PROVIDER_SQL = """
+SELECT enrolled_2025 AS present_in_2025_enrollment_file,
+       revoked_2026  AS present_in_2026_revocation_file,
+       medicare_participating AS medicare_participating_ind,
+       provider_type,
+       provider_total_benes
+FROM provider_features
+WHERE npi = %s
+"""
+
+_PEER_SQL = """
+SELECT count(*)                          AS peer_count,
+       avg(tot_srvcs)                    AS avg_srvcs,
+       stddev_pop(tot_srvcs)             AS std_srvcs,
+       avg(services_per_bene)            AS avg_spb,
+       stddev_pop(services_per_bene)     AS std_spb,
+       avg(submitted_to_allowed_ratio)   AS avg_ratio,
+       stddev_pop(submitted_to_allowed_ratio) AS std_ratio,
+       avg(avg_medicare_payment_amt)     AS avg_payment,
+       stddev_pop(avg_medicare_payment_amt)   AS std_payment
+FROM provider_service_cases
+WHERE provider_type = %s
+  AND hcpcs_cd = %s
+  AND npi != %s
+"""
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _z_score(value: float | None, mean: float | None, std: float | None) -> float | None:
+    """Compute z-score, returning None if inputs are missing or std is zero."""
+    if value is None or mean is None or std is None or std == 0:
+        return None
+    return (value - mean) / std
+
+
+def _fired_to_signal(fs: FiredSignal) -> Signal:
+    """Map an internal FiredSignal to the API Signal schema."""
+    return Signal(
+        name=fs.signal.name,
+        category=fs.signal.category,
+        direction=fs.signal.direction.value,
+        value=fs.value,
+        threshold=fs.signal.threshold,
+        description=fs.reason or fs.signal.description,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Endpoint
+# ---------------------------------------------------------------------------
+
+
+@router.post("", response_model=ScoreResult)
+async def score_claim(
+    req: ScoreRequest,
+    conn: AsyncConnection = Depends(get_db),
+) -> ScoreResult:
+    """Score a claim on the fly.
+
+    Looks up the provider profile and peer baselines from the database,
+    computes z-scores from the submitted values, and runs the scoring engine.
+    """
+    # 1. Look up provider profile
+    async with conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute(_PROVIDER_SQL, [req.npi])
+        provider = await cur.fetchone()
+
+    if not provider:
+        raise HTTPException(status_code=404, detail=f"Provider {req.npi} not found")
+
+    # 2. Build base case dict from provider profile
+    case: dict = {
+        "present_in_2025_enrollment_file": provider["present_in_2025_enrollment_file"],
+        "present_in_2026_revocation_file": provider["present_in_2026_revocation_file"],
+        "medicare_participating_ind": provider["medicare_participating_ind"],
+        "provider_total_benes": provider["provider_total_benes"],
+    }
+
+    # 3. Fetch peer baselines and compute z-scores (if HCPCS provided)
+    if req.hcpcs_cd:
+        async with conn.cursor(row_factory=dict_row) as cur:
+            await cur.execute(_PEER_SQL, [provider["provider_type"], req.hcpcs_cd, req.npi])
+            peers = await cur.fetchone()
+
+        if peers and (peers["peer_count"] or 0) >= MIN_PEER_COUNT:
+            case["peer_case_count"] = peers["peer_count"]
+            case["peer_avg_tot_srvcs"] = peers["avg_srvcs"]
+
+            case["service_volume_peer_z"] = _z_score(
+                req.tot_srvcs, peers["avg_srvcs"], peers["std_srvcs"]
+            )
+            case["services_per_bene_peer_z"] = None  # no bene count in request
+            case["submitted_to_allowed_peer_z"] = None  # no allowed amount in request
+            case["payment_peer_z"] = None  # no payment amount in request
+
+    # 4. Score
+    card = score_case(case)
+
+    # 5. Map to API response
+    risk_band = risk_band_from_score(card.risk_score)
+    signals = [_fired_to_signal(fs) for fs in card.signals]
+
+    return ScoreResult(
+        npi=req.npi,
+        risk_score=card.risk_score,
+        legitimacy_score=card.legitimacy_score,
+        risk_band=risk_band,  # type: ignore[arg-type]
+        signals=signals,
+    )

--- a/tests/test_score_endpoint.py
+++ b/tests/test_score_endpoint.py
@@ -1,0 +1,262 @@
+"""Tests for POST /api/score — on-the-fly scoring endpoint."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+
+import httpx
+from fastapi import FastAPI
+
+from src.api.deps import get_db
+from src.api.routes.score import router
+
+# ---------------------------------------------------------------------------
+# Fake DB layer
+# ---------------------------------------------------------------------------
+
+ENROLLED_PROVIDER = {
+    "present_in_2025_enrollment_file": 1,
+    "present_in_2026_revocation_file": 0,
+    "medicare_participating_ind": "Y",
+    "provider_type": "Internal Medicine",
+    "provider_total_benes": 200.0,
+}
+
+REVOKED_PROVIDER = {
+    "present_in_2025_enrollment_file": 0,
+    "present_in_2026_revocation_file": 1,
+    "medicare_participating_ind": "N",
+    "provider_type": "Internal Medicine",
+    "provider_total_benes": 30.0,
+}
+
+PEER_STATS_NORMAL = {
+    "peer_count": 50,
+    "avg_srvcs": 100.0,
+    "std_srvcs": 20.0,
+    "avg_spb": 5.0,
+    "std_spb": 1.0,
+    "avg_ratio": 1.2,
+    "std_ratio": 0.3,
+    "avg_payment": 80.0,
+    "std_payment": 15.0,
+}
+
+PEER_STATS_TOO_FEW = {**PEER_STATS_NORMAL, "peer_count": 5}
+
+
+class _ScoreCursor:
+    """Cursor that returns results from a shared queue."""
+
+    def __init__(self, results: list[dict | None]):
+        self._results = results
+
+    async def execute(self, sql: str, params: list | None = None):
+        pass
+
+    async def fetchone(self) -> dict | None:
+        return self._results.pop(0) if self._results else None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        pass
+
+
+class _FakeConn:
+    """Fake connection that returns provider on first cursor, peers on second."""
+
+    def __init__(self, provider: dict | None, peers: dict | None = None):
+        self._queue: list[dict | None] = [provider]
+        if peers is not None:
+            self._queue.append(peers)
+
+    def cursor(self, row_factory=None):
+        result = self._queue.pop(0) if self._queue else None
+        return _ScoreCursor([result])
+
+
+def _make_app(provider: dict | None, peers: dict | None = None) -> FastAPI:
+    @asynccontextmanager
+    async def _noop_lifespan(app: FastAPI):
+        yield
+
+    test_app = FastAPI(lifespan=_noop_lifespan)
+    test_app.include_router(router, prefix="/api")
+
+    conn = _FakeConn(provider, peers)
+
+    async def fake_db():
+        yield conn
+
+    test_app.dependency_overrides[get_db] = fake_db
+    return test_app
+
+
+# ---------------------------------------------------------------------------
+# Tests — provider not found
+# ---------------------------------------------------------------------------
+
+
+class TestProviderNotFound:
+    async def test_unknown_npi_returns_404(self):
+        app = _make_app(provider=None)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post("/api/score", json={"npi": "0000000000"})
+
+        assert resp.status_code == 404
+        assert "not found" in resp.json()["detail"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Tests — NPI-only scoring (no HCPCS)
+# ---------------------------------------------------------------------------
+
+
+class TestNpiOnlyScoring:
+    async def test_enrolled_provider_npi_only(self):
+        """Without HCPCS, only enrollment signals fire."""
+        app = _make_app(provider=ENROLLED_PROVIDER)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post("/api/score", json={"npi": "1234567890"})
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["npi"] == "1234567890"
+        # Enrolled + no revocation + participating + large panel
+        assert body["legitimacy_score"] > 0
+        assert body["risk_score"] == 0
+        assert body["risk_band"] == "stable"
+
+    async def test_revoked_provider_npi_only(self):
+        app = _make_app(provider=REVOKED_PROVIDER)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post("/api/score", json={"npi": "9999999999"})
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["risk_score"] > 0
+        assert body["risk_band"] in ("review", "high_risk")
+
+
+# ---------------------------------------------------------------------------
+# Tests — scoring with HCPCS and peer baselines
+# ---------------------------------------------------------------------------
+
+
+class TestScoringWithPeers:
+    async def test_normal_volume_no_risk(self):
+        """tot_srvcs near the peer average → no volume outlier."""
+        app = _make_app(provider=ENROLLED_PROVIDER, peers=PEER_STATS_NORMAL)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/api/score",
+                json={"npi": "1234567890", "hcpcs_cd": "99213", "tot_srvcs": 110.0},
+            )
+
+        body = resp.json()
+        assert body["risk_score"] == 0
+        assert body["risk_band"] == "stable"
+
+    async def test_extreme_volume_fires_risk(self):
+        """tot_srvcs far above peer average → volume outlier signal fires."""
+        app = _make_app(provider=ENROLLED_PROVIDER, peers=PEER_STATS_NORMAL)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            # z = (500 - 100) / 20 = 20.0 → extreme outlier
+            resp = await client.post(
+                "/api/score",
+                json={"npi": "1234567890", "hcpcs_cd": "99213", "tot_srvcs": 500.0},
+            )
+
+        body = resp.json()
+        assert body["risk_score"] > 0
+        signal_names = [s["name"] for s in body["signals"]]
+        assert "service_volume_outlier" in signal_names
+
+    async def test_too_few_peers_skips_z_scores(self):
+        """When peer count < MIN_PEER_COUNT, z-score signals don't fire."""
+        app = _make_app(provider=ENROLLED_PROVIDER, peers=PEER_STATS_TOO_FEW)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/api/score",
+                json={"npi": "1234567890", "hcpcs_cd": "99213", "tot_srvcs": 500.0},
+            )
+
+        body = resp.json()
+        # No volume outlier because peers < MIN_PEER_COUNT
+        signal_names = [s["name"] for s in body["signals"]]
+        assert "service_volume_outlier" not in signal_names
+
+
+# ---------------------------------------------------------------------------
+# Tests — response structure
+# ---------------------------------------------------------------------------
+
+
+class TestScoreResponseStructure:
+    async def test_response_has_required_fields(self):
+        app = _make_app(provider=ENROLLED_PROVIDER)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post("/api/score", json={"npi": "1234567890"})
+
+        body = resp.json()
+        assert "npi" in body
+        assert "risk_score" in body
+        assert "legitimacy_score" in body
+        assert "risk_band" in body
+        assert "signals" in body
+        assert isinstance(body["signals"], list)
+
+    async def test_signal_structure(self):
+        app = _make_app(provider=ENROLLED_PROVIDER)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post("/api/score", json={"npi": "1234567890"})
+
+        body = resp.json()
+        assert len(body["signals"]) > 0
+        sig = body["signals"][0]
+        assert "name" in sig
+        assert "category" in sig
+        assert "direction" in sig
+        assert "description" in sig
+
+    async def test_scores_within_bounds(self):
+        app = _make_app(provider=REVOKED_PROVIDER, peers=PEER_STATS_NORMAL)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/api/score",
+                json={"npi": "9999999999", "hcpcs_cd": "99213", "tot_srvcs": 500.0},
+            )
+
+        body = resp.json()
+        assert 0 <= body["risk_score"] <= 100
+        assert 0 <= body["legitimacy_score"] <= 100
+        assert body["risk_band"] in ("stable", "review", "high_risk")
+
+    async def test_request_validation_missing_npi(self):
+        app = _make_app(provider=ENROLLED_PROVIDER)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post("/api/score", json={})
+
+        assert resp.status_code == 422


### PR DESCRIPTION
## Summary

Closes #26

Adds `POST /api/score` — scores a claim that isn't in the database yet by looking up the provider profile and computing z-scores against peer baselines in real time.

**Flow:**
1. Look up provider by NPI from `provider_features` (enrollment, revocation, participating, total benes)
2. If HCPCS code provided, query peer baselines from `provider_service_cases` (same provider type + HCPCS, excluding the target NPI)
3. Compute volume z-score from submitted `tot_srvcs` vs peer mean/stddev
4. Run through `score_case()` — same scoring engine used for batch data
5. Map `FiredSignal` → API `Signal` schema, return `ScoreResult`

**New files:**
- `src/api/routes/score.py` — endpoint + DB queries + z-score computation + signal mapping
- `tests/test_score_endpoint.py` — 10 tests covering 404, NPI-only scoring, peer-based scoring, too-few-peers gating, response structure, input validation

**Modified:**
- `src/api/app.py` — registered score router

## Test plan

- [x] `ruff check` + `ruff format --check` — all clean
- [x] `mypy src/` — no issues (19 source files)
- [x] `pytest --cov=src -q` — 120 passed, 74% coverage
- [x] `score.py` route at 98% coverage
- [x] BASSPC self-review passed