### PR TITLE
feat(api): add claims list endpoint with pagination and filtering (#37)

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -35,10 +35,12 @@ def create_app() -> FastAPI:
     )
 
     # --- Routers ---
+    from src.api.routes.claims import router as claims_router
     from src.api.routes.providers import router as providers_router
     from src.api.routes.score import router as score_router
 
     app.include_router(providers_router, prefix="/api")
+    app.include_router(claims_router, prefix="/api")
     app.include_router(score_router, prefix="/api")
 
     # --- Health endpoint (no router needed) ---

--- a/src/api/routes/claims.py
+++ b/src/api/routes/claims.py
@@ -1,0 +1,90 @@
+"""Claims list endpoint — paginated provider-service cases with filtering."""
+
+from __future__ import annotations
+
+import math
+
+from fastapi import APIRouter, Depends, Query
+from psycopg import AsyncConnection
+from psycopg.rows import dict_row
+
+from src.api.deps import get_db
+from src.api.schemas import Claim, ClaimListResponse, PaginationMeta
+
+router = APIRouter(prefix="/claims", tags=["claims"])
+
+_COLS = (
+    "case_id, npi, provider_last_org_name, provider_first_name, "
+    "provider_credentials, provider_entity_code, provider_city, provider_state, "
+    "provider_zip5, provider_type, medicare_participating_ind, "
+    "hcpcs_cd, hcpcs_desc, place_of_service, "
+    "tot_benes, tot_srvcs, tot_bene_day_srvcs, "
+    "avg_submitted_charge, avg_medicare_allowed_amt, avg_medicare_payment_amt, "
+    "estimated_case_payment_amt, services_per_bene, "
+    "submitted_to_allowed_ratio, payment_to_allowed_ratio, "
+    "peer_scope, peer_case_count, peer_avg_tot_srvcs, "
+    "service_volume_peer_z, services_per_bene_peer_z, "
+    "submitted_to_allowed_peer_z, payment_peer_z, "
+    "seed_risk_score, seed_legitimacy_score, seed_case_label, "
+    "seed_risk_reasons, seed_legitimacy_reasons"
+)
+
+
+@router.get("", response_model=ClaimListResponse)
+async def list_claims(
+    page: int = Query(1, ge=1),
+    per_page: int = Query(50, ge=1, le=200),
+    npi: str | None = None,
+    case_label: str | None = None,
+    state: str | None = None,
+    provider_type: str | None = None,
+    risk_min: int | None = Query(None, ge=0, le=100),
+    risk_max: int | None = Query(None, ge=0, le=100),
+    conn: AsyncConnection = Depends(get_db),
+) -> ClaimListResponse:
+    conditions: list[str] = []
+    params: list[object] = []
+
+    if npi:
+        conditions.append("npi = %s")
+        params.append(npi)
+    if case_label:
+        conditions.append("seed_case_label = %s")
+        params.append(case_label)
+    if state:
+        conditions.append("provider_state = %s")
+        params.append(state)
+    if provider_type:
+        conditions.append("provider_type = %s")
+        params.append(provider_type)
+    if risk_min is not None:
+        conditions.append("seed_risk_score >= %s")
+        params.append(risk_min)
+    if risk_max is not None:
+        conditions.append("seed_risk_score <= %s")
+        params.append(risk_max)
+
+    where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+
+    async with conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute(f"SELECT count(*) AS cnt FROM provider_service_cases {where}", params)
+        row = await cur.fetchone()
+        total = row["cnt"] if row else 0
+
+        offset = (page - 1) * per_page
+        await cur.execute(
+            f"SELECT {_COLS} FROM provider_service_cases {where} "
+            "ORDER BY seed_risk_score DESC NULLS LAST "
+            "LIMIT %s OFFSET %s",
+            [*params, per_page, offset],
+        )
+        rows = await cur.fetchall()
+
+    data = [Claim(**r) for r in rows]
+    meta = PaginationMeta(
+        total=total,
+        page=page,
+        per_page=per_page,
+        pages=math.ceil(total / per_page) if total else 0,
+    )
+    return ClaimListResponse(data=data, meta=meta)

--- a/tests/test_claims.py
+++ b/tests/test_claims.py
@@ -1,0 +1,244 @@
+"""Tests for GET /api/claims — paginated provider-service cases."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+
+import httpx
+from fastapi import FastAPI
+
+from src.api.deps import get_db
+from src.api.routes.claims import router
+
+# ---------------------------------------------------------------------------
+# Fake DB layer
+# ---------------------------------------------------------------------------
+
+SAMPLE_CASE = {
+    "case_id": "1234567890-99213",
+    "npi": "1234567890",
+    "provider_last_org_name": "ACME MEDICAL",
+    "provider_first_name": "JANE",
+    "provider_credentials": "M.D.",
+    "provider_entity_code": "I",
+    "provider_city": "Los Angeles",
+    "provider_state": "CA",
+    "provider_zip5": "90001",
+    "provider_type": "Internal Medicine",
+    "medicare_participating_ind": "Y",
+    "hcpcs_cd": "99213",
+    "hcpcs_desc": "Office/outpatient visit est",
+    "place_of_service": "F",
+    "tot_benes": 50.0,
+    "tot_srvcs": 200.0,
+    "tot_bene_day_srvcs": 150.0,
+    "avg_submitted_charge": 120.0,
+    "avg_medicare_allowed_amt": 80.0,
+    "avg_medicare_payment_amt": 65.0,
+    "estimated_case_payment_amt": 13000.0,
+    "services_per_bene": 4.0,
+    "submitted_to_allowed_ratio": 1.5,
+    "payment_to_allowed_ratio": 0.81,
+    "peer_scope": "state_specific",
+    "peer_case_count": 45,
+    "peer_avg_tot_srvcs": 120.0,
+    "service_volume_peer_z": 2.5,
+    "services_per_bene_peer_z": 1.2,
+    "submitted_to_allowed_peer_z": 0.8,
+    "payment_peer_z": 0.5,
+    "seed_risk_score": 42,
+    "seed_legitimacy_score": 55,
+    "seed_case_label": "review",
+    "seed_risk_reasons": "volume outlier",
+    "seed_legitimacy_reasons": "enrolled, no revocation",
+}
+
+
+class _ListCursor:
+    def __init__(self, count: int, rows: list[dict]):
+        self._count = count
+        self._rows = rows
+        self._call = 0
+
+    async def execute(self, sql: str, params: list | None = None):
+        self._call += 1
+
+    async def fetchone(self) -> dict | None:
+        return {"cnt": self._count}
+
+    async def fetchall(self) -> list[dict]:
+        return self._rows
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        pass
+
+
+class _FakeConn:
+    def __init__(self, rows: list[dict], count: int | None = None):
+        self._rows = rows
+        self._count = count if count is not None else len(rows)
+
+    def cursor(self, row_factory=None):
+        return _ListCursor(self._count, self._rows)
+
+
+def _make_app(rows: list[dict], count: int | None = None) -> FastAPI:
+    @asynccontextmanager
+    async def _noop_lifespan(app: FastAPI):
+        yield
+
+    test_app = FastAPI(lifespan=_noop_lifespan)
+    test_app.include_router(router, prefix="/api")
+
+    conn = _FakeConn(rows, count)
+
+    async def fake_db():
+        yield conn
+
+    test_app.dependency_overrides[get_db] = fake_db
+    return test_app
+
+
+# ---------------------------------------------------------------------------
+# Tests — list endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestListClaims:
+    async def test_returns_data(self):
+        app = _make_app([SAMPLE_CASE])
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.get("/api/claims")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["data"]) == 1
+        assert body["data"][0]["case_id"] == "1234567890-99213"
+        assert body["data"][0]["npi"] == "1234567890"
+        assert body["data"][0]["seed_case_label"] == "review"
+        assert body["meta"]["total"] == 1
+
+    async def test_empty_list(self):
+        app = _make_app([], count=0)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.get("/api/claims")
+
+        body = resp.json()
+        assert body["data"] == []
+        assert body["meta"]["total"] == 0
+        assert body["meta"]["pages"] == 0
+
+    async def test_pagination_meta(self):
+        app = _make_app([SAMPLE_CASE], count=250)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.get("/api/claims?page=3&per_page=100")
+
+        body = resp.json()
+        assert body["meta"]["page"] == 3
+        assert body["meta"]["per_page"] == 100
+        assert body["meta"]["total"] == 250
+        assert body["meta"]["pages"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Tests — filters
+# ---------------------------------------------------------------------------
+
+
+class TestClaimFilters:
+    async def test_filter_by_npi(self):
+        app = _make_app([SAMPLE_CASE])
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.get("/api/claims?npi=1234567890")
+
+        assert resp.status_code == 200
+
+    async def test_filter_by_case_label(self):
+        app = _make_app([SAMPLE_CASE])
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.get("/api/claims?case_label=review")
+
+        assert resp.status_code == 200
+
+    async def test_filter_by_state(self):
+        app = _make_app([SAMPLE_CASE])
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.get("/api/claims?state=CA")
+
+        assert resp.status_code == 200
+
+    async def test_filter_by_risk_range(self):
+        app = _make_app([SAMPLE_CASE])
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.get("/api/claims?risk_min=30&risk_max=60")
+
+        assert resp.status_code == 200
+
+    async def test_combined_filters(self):
+        app = _make_app([SAMPLE_CASE])
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.get(
+                "/api/claims?state=CA&provider_type=Internal+Medicine&case_label=review&risk_min=30"
+            )
+
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Tests — validation
+# ---------------------------------------------------------------------------
+
+
+class TestClaimValidation:
+    async def test_per_page_too_high(self):
+        app = _make_app([])
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.get("/api/claims?per_page=999")
+
+        assert resp.status_code == 422
+
+    async def test_risk_min_out_of_range(self):
+        app = _make_app([])
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.get("/api/claims?risk_min=-1")
+
+        assert resp.status_code == 422
+
+    async def test_response_structure(self):
+        app = _make_app([SAMPLE_CASE])
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.get("/api/claims")
+
+        body = resp.json()
+        claim = body["data"][0]
+        assert "case_id" in claim
+        assert "npi" in claim
+        assert "hcpcs_cd" in claim
+        assert "seed_risk_score" in claim
+        assert "seed_case_label" in claim
+        assert "peer_case_count" in claim


### PR DESCRIPTION
## Summary

Closes #37

Adds `GET /api/claims` — paginated list of provider-service cases from `provider_service_cases` table.

**Filters:** `npi`, `case_label`, `state`, `provider_type`, `risk_min`, `risk_max`
**Sort:** `seed_risk_score DESC NULLS LAST`
**Pagination:** `page` + `per_page` (max 200)

**New files:**
- `src/api/routes/claims.py` — endpoint with parameterized SQL queries
- `tests/test_claims.py` — 11 tests (list, filters, validation, response structure)

**Modified:**
- `src/api/app.py` — registered claims router

## Test plan

- [x] `ruff check` + `ruff format --check` — clean
- [x] `mypy src/` — no issues
- [x] `pytest --cov=src -q` — 131 passed, 75% coverage
- [x] `claims.py` at 100% coverage
- [x] BASSPC self-review passed