### PR TITLE
docs(scoring): add risk methodology and responsible AI docs (#55) (#56)

### DIFF
--- a/docs/responsible-ai-considerations.md
+++ b/docs/responsible-ai-considerations.md
@@ -1,0 +1,178 @@
+# Responsible AI Considerations
+
+## Overview
+
+The CMS Fraud Detection system is designed to assist human investigators — not replace them. Every design decision prioritizes explainability, fairness, and accountability over raw predictive power.
+
+## 1. Dual Scoring: Risk and Legitimacy
+
+Traditional fraud detection systems produce a single risk score. This creates a one-dimensional view that ignores evidence of legitimate practice.
+
+Our system computes **two independent scores** for every provider-service case:
+
+- **Risk Score**: Quantifies how anomalous the billing pattern is relative to peers
+- **Legitimacy Score**: Quantifies how many trust-building indicators the provider exhibits
+
+A provider with high volume (risk signal) who is enrolled, participating in Medicare, and within normal range on all other metrics (legitimacy signals) will show a high legitimacy score that contextualizes the risk. The case label rules require risk to exceed legitimacy by at least 5 points before a `high_risk` label is assigned.
+
+This dual-score design reduces false positives and ensures providers aren't flagged solely on a single anomalous metric.
+
+## 2. Fairness Monitoring
+
+### Built-In Fairness Endpoint
+
+The system includes a dedicated `/api/fairness` endpoint that computes flagging rate disparities across two protected dimensions:
+
+- **Geography** (state): Ensures no state's providers are disproportionately flagged
+- **Specialty** (provider_type): Ensures no medical specialty is disproportionately flagged
+
+### Metrics Computed
+
+| Metric                            | Definition                                         | Ideal Value          |
+| --------------------------------- | -------------------------------------------------- | -------------------- |
+| **Overall Flagging Rate**         | Fraction of providers with risk score >= threshold | N/A (descriptive)    |
+| **Statistical Parity Difference** | max(cohort rate) - min(cohort rate)                | 0.0 (perfect parity) |
+| **Disparate Impact Ratio**        | min(cohort rate) / max(cohort rate)                | 1.0 (perfect parity) |
+| **Outlier Detection**             | Cohort rate > 2 standard deviations above mean     | Flags systemic bias  |
+
+### Four-Fifths Rule
+
+The disparate impact ratio maps directly to the EEOC's four-fifths (80%) rule used in employment discrimination analysis. A ratio below 0.80 warrants investigation into whether the scoring methodology introduces unintended bias against certain specialties or regions.
+
+### Configurable Threshold
+
+The fairness endpoint accepts a `threshold` parameter (default: 51), allowing analysts to evaluate fairness at different risk cutoffs without code changes.
+
+## 3. Explainability
+
+### Signal-Level Transparency
+
+Every score decomposes into specific, named signals. A reviewer can see exactly which signals fired, what values triggered them, and how many points each contributed.
+
+Example output for a flagged provider:
+
+```
+Risk Score: 67
+  - revoked_provider:           25 pts  (appears in 2026 revocation file)
+  - service_volume_outlier:     20 pts  (z = 5.3, tier 1: z >= 5.0)
+  - service_intensity_outlier:  14 pts  (z = 3.8, tier 2: z >= 3.0)
+  - charge_ratio_outlier:        8 pts  (z = 2.4, tier 3: z >= 2.0)
+
+Legitimacy Score: 8
+  - large_patient_panel:         8 pts  (serves 150 beneficiaries)
+```
+
+No score is a mystery — every point has a name, a source, and a reason.
+
+### Peer Comparison Context
+
+For peer-based signals, the system shows:
+
+- The peer group scope (same specialty + HCPCS code)
+- The peer group size (minimum 25 required)
+- The peer average and the provider's observed value
+- The z-score that quantifies the deviation
+
+This allows reviewers to judge whether the peer comparison is meaningful for the specific case.
+
+## 4. Human-in-the-Loop Design
+
+### The System Does Not Make Decisions
+
+The system produces scores, signals, and evidence packages. It does **not**:
+
+- Automatically flag providers for enforcement action
+- Generate formal accusations or referrals
+- Remove providers from the Medicare program
+- Deny or approve claims
+
+All outputs are decision-support artifacts for trained investigators who apply domain expertise and additional context.
+
+### Three-Tier Case Labels
+
+Cases are labeled `high_risk`, `review`, or `stable` — not "fraudulent" or "legitimate." The language reflects that these are risk indicators requiring human evaluation, not conclusions.
+
+### Investigator Workflow
+
+1. Analysts review the provider list sorted by risk score
+2. For flagged providers, they examine fired signals and peer comparisons
+3. They assess whether the anomalies have legitimate explanations (e.g., specialty clinics naturally have higher volume for certain codes)
+4. Only after human review does a case proceed to further investigation
+
+## 5. Data Provenance and Transparency
+
+### Public Data Only
+
+All scoring inputs come from publicly available CMS datasets:
+
+- **Medicare Fee-for-Service Public Provider Enrollment** (2025): Enrollment verification
+- **CMS Provider Revocation File** (2026): Revocation status
+- **Medicare Physician & Other Practitioners** (2022): Service volume, charges, payments
+
+No proprietary data, patient records, or protected health information is used.
+
+### No Demographic Data
+
+The scoring engine does **not** use any demographic variables — no race, ethnicity, gender, age, or socioeconomic indicators. Scores are based entirely on:
+
+- Enrollment/revocation status (administrative records)
+- Billing volume compared to specialty-specific peers (statistical comparison)
+- Charge ratios compared to peers (statistical comparison)
+
+### Reproducibility
+
+The scoring engine is deterministic: the same input always produces the same output. There is no randomness, no model re-training, and no stochastic inference. This means:
+
+- Results can be independently verified
+- Auditors can reproduce any score by running the same data through the same code
+- Scoring behavior is predictable and testable
+
+## 6. Limitations and Known Constraints
+
+### What This System Cannot Detect
+
+- **Collusion between providers**: Requires network analysis beyond peer comparison
+- **Phantom patients**: Requires beneficiary-level validation not in the current dataset
+- **Upcoding within normal ranges**: Providers billing at the high end of normal will not trigger z-score signals
+- **New fraud schemes**: A rule-based system detects known anomaly patterns, not novel ones
+
+### Peer Group Limitations
+
+- Peer groups with fewer than 25 members are suppressed to avoid unreliable comparisons
+- National specialties with few practitioners may have skewed baselines
+- The 2022 billing data may not reflect current practice patterns
+
+### Score Ceiling Effects
+
+- The maximum legitimacy score (89) is lower than the theoretical risk maximum (100), which slightly favors risk in extreme cases
+- This is an intentional design choice: a provider exhibiting extreme anomalies across all metrics should not be fully offset by standard legitimacy indicators
+
+## 7. AI Disclosure
+
+This system uses **deterministic rule-based scoring** rather than machine learning models. The current implementation:
+
+- Does **not** use neural networks, gradient-boosted trees, or other ML models for scoring
+- Does **not** use generative AI for producing scores or labels
+- **Does** use peer-comparison statistics (z-scores) that are transparent and interpretable
+
+If AI-generated narratives are added in a future phase, they will be clearly labeled as AI-generated content and will serve as supplementary context — never as the basis for scoring or labeling decisions.
+
+## 8. Continuous Improvement
+
+### Monitoring Plan
+
+- Track fairness metrics at each scoring run via the `/api/fairness` endpoint
+- Alert if any cohort's flagging rate exceeds 2 standard deviations from the mean
+- Review disparate impact ratios quarterly
+
+### Feedback Loop
+
+- Investigators can provide feedback on flagged cases (true positive, false positive)
+- This feedback informs threshold tuning and signal weight adjustments
+- All changes to scoring logic are versioned in code and documented
+
+### Audit Trail
+
+- All scoring parameters (thresholds, weights, tier boundaries) are defined in `src/scoring/taxonomy.py`
+- Changes to scoring logic go through code review and CI checks
+- Historical scores are preserved in the database for comparison

--- a/docs/risk-scoring-methodology.md
+++ b/docs/risk-scoring-methodology.md
@@ -1,0 +1,134 @@
+# Risk Scoring Methodology
+
+## Overview
+
+The CMS Fraud Detection system uses a deterministic, explainable scoring engine to evaluate Medicare provider-service cases. Every score is traceable to specific signals, thresholds, and data sources — there are no black-box models.
+
+Each provider-service case (one provider + one HCPCS code) receives two independent scores:
+
+- **Risk Score** (0-100): How anomalous the billing pattern is compared to peers
+- **Legitimacy Score** (0-100): How many trust-building indicators the provider exhibits
+
+The dual-score design prevents false positives: a high risk score alone does not trigger a flag if legitimacy evidence is strong.
+
+## Architecture
+
+The scoring engine is a pure-function, three-layer stack:
+
+```
+taxonomy.py   →  Signal definitions, thresholds, point allocations
+extract.py    →  Maps a case row to fired signals with points
+score.py      →  Sums fired signals into scores and assigns a case label
+```
+
+All logic is database-free and fully unit-testable.
+
+## Signal Taxonomy
+
+### Risk Signals (6 signals)
+
+| Signal                           | Category   | Trigger                                               | Points      |
+| -------------------------------- | ---------- | ----------------------------------------------------- | ----------- |
+| `revoked_provider`               | enrollment | Provider appears in 2026 CMS revocation file          | 25          |
+| `not_in_current_enrollment_file` | enrollment | Provider absent from 2025 CMS enrollment file         | 8           |
+| `service_volume_outlier`         | peer       | Total services z-score vs. peers (tiered)             | 8 / 14 / 20 |
+| `service_intensity_outlier`      | peer       | Services-per-beneficiary z-score vs. peers (tiered)   | 7 / 12 / 18 |
+| `charge_ratio_outlier`           | peer       | Submitted-to-allowed ratio z-score vs. peers (tiered) | 7 / 12 / 18 |
+| `payment_outlier`                | peer       | Average payment z-score vs. peers (tiered)            | 5 / 8 / 12  |
+
+### Legitimacy Signals (7 signals)
+
+| Signal                               | Category   | Trigger                                                   | Points |
+| ------------------------------------ | ---------- | --------------------------------------------------------- | ------ |
+| `present_in_current_enrollment_file` | enrollment | Provider found in 2025 enrollment file                    | 20     |
+| `no_revocation_match`                | enrollment | Provider has no revocation on record                      | 15     |
+| `medicare_participating`             | enrollment | Provider accepts Medicare assignment                      | 10     |
+| `peer_aligned_volume`                | peer       | Service volume within 1 std. dev. of peers (\|z\| < 1.0)  | 12     |
+| `peer_aligned_intensity`             | peer       | Services per beneficiary within 1 std. dev. (\|z\| < 1.0) | 12     |
+| `peer_aligned_pricing`               | peer       | Charge ratio within 1 std. dev. (\|z\| < 1.0)             | 12     |
+| `large_patient_panel`                | volume     | Provider serves 100+ Medicare beneficiaries               | 8      |
+
+## Z-Score Tier System
+
+Peer-comparison risk signals use a graduated tier system rather than a binary threshold. This rewards proportional response — a provider 5 standard deviations above peers is scored more heavily than one at 2.
+
+| Tier              | Z-Score  | Volume Points | Intensity Points | Charge Points | Payment Points |
+| ----------------- | -------- | ------------- | ---------------- | ------------- | -------------- |
+| Tier 1 (extreme)  | z >= 5.0 | 20            | 18               | 18            | 12             |
+| Tier 2 (high)     | z >= 3.0 | 14            | 12               | 12            | 8              |
+| Tier 3 (elevated) | z >= 2.0 | 8             | 7                | 7             | 5              |
+| Below threshold   | z < 2.0  | 0             | 0                | 0             | 0              |
+
+## Peer Baseline Construction
+
+Z-scores are computed against peer groups defined by **provider specialty (provider_type) and HCPCS code**. A peer group must have at least **25 providers** (`MIN_PEER_COUNT`) to produce statistically meaningful comparisons.
+
+Peer baselines are pre-computed in the `provider_service_cases` table:
+
+- `peer_avg_tot_srvcs` — mean total services across peers
+- `service_volume_peer_z` — (provider's total services - peer mean) / peer std dev
+- `services_per_bene_peer_z` — same formula for services per beneficiary
+- `submitted_to_allowed_peer_z` — same for charge ratio
+- `payment_peer_z` — same for average Medicare payment
+
+If the peer group has fewer than 25 members, all peer-based signals are suppressed for that case.
+
+## Score Computation
+
+```
+risk_score      = min(sum(risk signal points), 100)
+legitimacy_score = min(sum(legitimacy signal points), 100)
+```
+
+### Theoretical Maximums
+
+- **Max risk score**: 101 points possible (capped at 100)
+  - Revoked (25) + Not enrolled (8) + Volume tier 1 (20) + Intensity tier 1 (18) + Charge tier 1 (18) + Payment tier 1 (12)
+- **Max legitimacy score**: 89 points possible
+  - Enrolled (20) + No revocation (15) + Participating (10) + Volume aligned (12) + Intensity aligned (12) + Pricing aligned (12) + Large panel (8)
+
+## Case Labeling
+
+After scoring, each case receives a label based on decision rules:
+
+| Label       | Criteria                                                |
+| ----------- | ------------------------------------------------------- |
+| `high_risk` | risk_score >= 50 AND risk_score >= legitimacy_score + 5 |
+| `stable`    | legitimacy_score >= 70 AND risk_score < 30              |
+| `review`    | All other cases                                         |
+
+The gap requirement (`risk >= legitimacy + 5`) prevents flagging when a provider has strong legitimacy evidence counterbalancing moderate risk signals.
+
+## Provider-Level Risk Bands
+
+For the provider list view, the maximum `seed_risk_score` across all service lines determines the provider's display band:
+
+| Band        | Score Range |
+| ----------- | ----------- |
+| `high_risk` | 51-100      |
+| `review`    | 31-50       |
+| `stable`    | 0-30        |
+
+## Data Provenance
+
+Every signal traces directly to a CMS public dataset:
+
+| Data Source                       | Signal Category | CMS Dataset                                                |
+| --------------------------------- | --------------- | ---------------------------------------------------------- |
+| Enrollment status                 | enrollment      | Medicare Fee-for-Service Public Provider Enrollment (2025) |
+| Revocation status                 | enrollment      | CMS Revocation File (2026)                                 |
+| Service volume, charges, payments | peer            | Medicare Physician & Other Practitioners (2022)            |
+| Beneficiary counts                | volume          | Same as above                                              |
+
+All datasets are publicly available from [data.cms.gov](https://data.cms.gov).
+
+## Explainability
+
+Every scored case carries:
+
+- The complete list of fired signals with their point contributions
+- Human-readable reason strings for each signal
+- The observed value (e.g., z-score of 4.2) and the threshold that triggered it
+- The peer baseline value for context
+
+This enables reviewers to understand exactly why a provider was flagged and trace every point back to a specific data source and comparison methodology.


### PR DESCRIPTION
## Summary
- **risk-scoring-methodology.md**: Complete documentation of the deterministic scoring formula — signal taxonomy (13 signals), z-score tier system, peer baseline construction, case labeling rules, data provenance
- **responsible-ai-considerations.md**: Dual scoring rationale, fairness monitoring (statistical parity, disparate impact), explainability design, human-in-the-loop workflow, limitations disclosure, AI transparency

Both docs are judge-facing deliverables for the hackathon submission.

Closes #55
Closes #56

## Test plan
- [x] All numbers verified against `src/scoring/taxonomy.py`
- [x] Fairness metrics verified against `src/api/routes/fairness.py`
- [x] BASSPC self-review — all pass