### PR TITLE
feat(infra): scaffold Terraform project with ECR and IAM (#122)

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/terraform/bootstrap.sh
+++ b/terraform/bootstrap.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Bootstrap Terraform state backend (run once, before terraform init)
+# Creates S3 bucket + DynamoDB table for remote state locking.
+set -euo pipefail
+
+PROFILE="precise-eng"
+REGION="us-east-1"
+BUCKET="cms-fraud-terraform-state"
+TABLE="cms-fraud-terraform-locks"
+
+echo "Creating S3 bucket: ${BUCKET}"
+aws s3api create-bucket \
+  --bucket "${BUCKET}" \
+  --region "${REGION}" \
+  --profile "${PROFILE}" 2>/dev/null || echo "  Bucket already exists"
+
+aws s3api put-bucket-versioning \
+  --bucket "${BUCKET}" \
+  --versioning-configuration Status=Enabled \
+  --profile "${PROFILE}"
+
+aws s3api put-bucket-encryption \
+  --bucket "${BUCKET}" \
+  --server-side-encryption-configuration '{
+    "Rules": [{"ApplyServerSideEncryptionByDefault": {"SSEAlgorithm": "AES256"}}]
+  }' \
+  --profile "${PROFILE}"
+
+aws s3api put-public-access-block \
+  --bucket "${BUCKET}" \
+  --public-access-block-configuration '{
+    "BlockPublicAcls": true,
+    "IgnorePublicAcls": true,
+    "BlockPublicPolicy": true,
+    "RestrictPublicBuckets": true
+  }' \
+  --profile "${PROFILE}"
+
+echo "Creating DynamoDB table: ${TABLE}"
+aws dynamodb create-table \
+  --table-name "${TABLE}" \
+  --attribute-definitions AttributeName=LockID,AttributeType=S \
+  --key-schema AttributeName=LockID,KeyType=HASH \
+  --billing-mode PAY_PER_REQUEST \
+  --region "${REGION}" \
+  --profile "${PROFILE}" 2>/dev/null || echo "  Table already exists"
+
+echo "Bootstrap complete. Run: cd terraform && terraform init"

--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -1,0 +1,48 @@
+resource "aws_ecr_repository" "api" {
+  name                 = "${var.project_name}-api"
+  image_tag_mutability = "IMMUTABLE"
+  force_delete         = false
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "api" {
+  repository = aws_ecr_repository.api.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Keep last 10 tagged images"
+        selection = {
+          tagStatus   = "tagged"
+          tagPrefixList = ["v"]
+          countType   = "imageCountMoreThan"
+          countNumber = 10
+        }
+        action = {
+          type = "expire"
+        }
+      },
+      {
+        rulePriority = 2
+        description  = "Remove untagged images after 7 days"
+        selection = {
+          tagStatus   = "untagged"
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = 7
+        }
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,0 +1,41 @@
+resource "aws_iam_user" "ci" {
+  name = "${var.project_name}-ci"
+}
+
+resource "aws_iam_access_key" "ci" {
+  user = aws_iam_user.ci.name
+}
+
+data "aws_iam_policy_document" "ci_ecr" {
+  statement {
+    sid    = "ECRAuth"
+    effect = "Allow"
+    actions = [
+      "ecr:GetAuthorizationToken",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "ECRPushPull"
+    effect = "Allow"
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:BatchGetImage",
+      "ecr:CompleteLayerUpload",
+      "ecr:DescribeImages",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:InitiateLayerUpload",
+      "ecr:ListImages",
+      "ecr:PutImage",
+      "ecr:UploadLayerPart",
+    ]
+    resources = [aws_ecr_repository.api.arn]
+  }
+}
+
+resource "aws_iam_user_policy" "ci_ecr" {
+  name   = "${var.project_name}-ci-ecr"
+  user   = aws_iam_user.ci.name
+  policy = data.aws_iam_policy_document.ci_ecr.json
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,21 @@
+output "ecr_repository_url" {
+  description = "ECR repository URL for backend image"
+  value       = aws_ecr_repository.api.repository_url
+}
+
+output "ci_user_arn" {
+  description = "ARN of the CI/CD IAM user"
+  value       = aws_iam_user.ci.arn
+}
+
+output "ci_user_access_key_id" {
+  description = "Access key ID for CI/CD user"
+  value       = aws_iam_access_key.ci.id
+  sensitive   = true
+}
+
+output "ci_user_secret_access_key" {
+  description = "Secret access key for CI/CD user"
+  value       = aws_iam_access_key.ci.secret
+  sensitive   = true
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,0 +1,12 @@
+provider "aws" {
+  region  = var.aws_region
+  profile = var.aws_profile
+
+  default_tags {
+    tags = {
+      Project     = var.project_name
+      Environment = var.environment
+      ManagedBy   = "terraform"
+    }
+  }
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,6 @@
+project_name   = "cms-fraud-detection"
+aws_region     = "us-east-1"
+aws_account_id = "376567172837"
+aws_profile    = "precise-eng"
+environment    = "dev"
+github_repo    = "precisesoft/cms-fraud-detection"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,35 @@
+variable "project_name" {
+  description = "Project name used for resource naming and tagging"
+  type        = string
+  default     = "cms-fraud-detection"
+}
+
+variable "aws_region" {
+  description = "AWS region for all resources"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "aws_account_id" {
+  description = "AWS account ID"
+  type        = string
+  default     = "376567172837"
+}
+
+variable "aws_profile" {
+  description = "AWS CLI profile to use"
+  type        = string
+  default     = "precise-eng"
+}
+
+variable "environment" {
+  description = "Deployment environment"
+  type        = string
+  default     = "dev"
+}
+
+variable "github_repo" {
+  description = "GitHub repository (org/repo format)"
+  type        = string
+  default     = "precisesoft/cms-fraud-detection"
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  backend "s3" {
+    bucket         = "cms-fraud-terraform-state"
+    key            = "cms-fraud-detection/terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "cms-fraud-terraform-locks"
+    encrypt        = true
+    profile        = "precise-eng"
+  }
+}


### PR DESCRIPTION
## Summary
- Scaffolds the Terraform project structure for AWS infrastructure
- ECR repository with immutable tags, scan-on-push, and lifecycle policy (keep 10 tagged, purge untagged after 7d)
- IAM CI user with least-privilege ECR push/pull policy
- S3 backend with DynamoDB locking (bootstrapped)
- `terraform init` + `terraform validate` + `terraform plan` all pass (5 resources to add)

## Files
| File | Purpose |
|------|---------|
| `versions.tf` | TF version, AWS provider, S3 backend |
| `providers.tf` | AWS provider with default tags |
| `variables.tf` | 6 project variables |
| `ecr.tf` | ECR repo + lifecycle policy |
| `iam.tf` | CI user + ECR policy |
| `outputs.tf` | ECR URL, CI user credentials |
| `bootstrap.sh` | One-time state backend creation |
| `terraform.tfvars.example` | Example values |

## Test plan
- [x] `terraform init` — S3 backend connected
- [x] `terraform validate` — configuration valid
- [x] `terraform plan` — 5 resources, clean plan

Closes #122