### PR TITLE
feat(ci): add ECR build and push workflow on merge to main (#116)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,48 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
+      - "terraform/**"
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  AWS_REGION: ${{ secrets.AWS_REGION }}
+  ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
+
+jobs:
+  build-push:
+    name: Build & Push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Login to ECR
+        id: ecr-login
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build, tag, and push image
+        env:
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build -t $ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REPOSITORY:latest .
+          docker push $ECR_REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REPOSITORY:latest
+          echo "### Image pushed" >> "$GITHUB_STEP_SUMMARY"
+          echo "- \`$ECR_REPOSITORY:$IMAGE_TAG\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- \`$ECR_REPOSITORY:latest\`" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- Adds `deploy.yml` workflow — builds and pushes backend image to ECR on merge to main
- Tags with git SHA (immutable for rollbacks) + `latest` (for ArgoCD)
- Skips on docs-only and terraform-only changes
- Uses existing GitHub secrets: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `ECR_REPOSITORY`

## Test plan
- [x] Workflow YAML is syntactically valid
- [x] Local CI checks pass (ruff, mypy, pytest)
- [ ] Will verify end-to-end on merge (pushes to `376567172837.dkr.ecr.us-east-1.amazonaws.com/cms-fraud-detection-api`)

Closes #116