### PR TITLE
feat(infra): add ArgoCD app + fix K8s deployment issues (#115)

### DIFF
--- a/k8s/argocd-app.yaml
+++ b/k8s/argocd-app.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cms-fraud
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/precisesoft/precise-manifests.git
+    targetRevision: main
+    path: k8s/cms-fraud
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: cms-fraud
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/k8s/cms-fraud/neo4j.yaml
+++ b/k8s/cms-fraud/neo4j.yaml
@@ -25,17 +25,24 @@ spec:
               containerPort: 7474
             - name: bolt
               containerPort: 7687
-          envFrom:
-            - secretRef:
-                name: neo4j-credentials
+          env:
+            - name: NEO4J_AUTH
+              valueFrom:
+                secretKeyRef:
+                  name: neo4j-credentials
+                  key: NEO4J_AUTH
+            - name: NEO4J_server_config_strict__validation_enabled
+              value: "false"
           volumeMounts:
             - name: data
               mountPath: /data
           readinessProbe:
-            exec:
-              command: ["cypher-shell", "-u", "neo4j", "-p", "cms_graph_dev", "RETURN 1"]
+            httpGet:
+              path: /
+              port: 7474
             initialDelaySeconds: 30
             periodSeconds: 10
+            timeoutSeconds: 5
           resources:
             requests:
               cpu: 250m

--- a/k8s/cms-fraud/postgres.yaml
+++ b/k8s/cms-fraud/postgres.yaml
@@ -25,6 +25,9 @@ spec:
           envFrom:
             - secretRef:
                 name: postgres-credentials
+          env:
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
           volumeMounts:
             - name: data
               mountPath: /var/lib/postgresql/data


### PR DESCRIPTION
## Summary
- ArgoCD Application CR for cms-fraud (auto-sync, self-heal, CreateNamespace)
- Fixed 3 deployment issues discovered during live deploy to EKS:
  1. Postgres: EBS `lost+found` conflict → set `PGDATA` subdirectory
  2. Neo4j: K8s service env var collision → disable strict config validation
  3. Neo4j: `cypher-shell` readiness probe timeout → switch to HTTP probe

## Verification (live on EKS)
- [x] ArgoCD: Synced + Healthy
- [x] Pods: postgres-0 (1/1), neo4j-0 (1/1), api-x2 (1/1)
- [x] `/health` → `{"status":"ok","database":"ok","graph":"ok","version":"0.1.0"}`
- [x] Manifests synced to `precisesoft/precise-manifests` repo

Closes #115