### PR TITLE
feat(frontend): live dashboard with API data and risk table (#59)

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,8 +1,83 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Activity, AlertTriangle, Eye, Users } from "lucide-react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Activity, AlertTriangle, Eye, ShieldCheck, Users } from "lucide-react";
+import { api } from "@/lib/api";
+import type { DashboardStats, ProviderSummary } from "@/types/api";
+import Link from "next/link";
 
-export default function DashboardPage() {
+function riskBadge(band: ProviderSummary["risk_band"]) {
+  switch (band) {
+    case "high_risk":
+      return <Badge variant="destructive">High Risk</Badge>;
+    case "review":
+      return (
+        <Badge className="bg-amber-100 text-amber-800 hover:bg-amber-200 border-amber-200">
+          Review
+        </Badge>
+      );
+    default:
+      return (
+        <Badge variant="outline" className="text-green-700 border-green-200">
+          Stable
+        </Badge>
+      );
+  }
+}
+
+function formatCurrency(value: number | null) {
+  if (value == null) return "\u2014";
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+function formatNumber(value: number | null) {
+  if (value == null) return "\u2014";
+  return new Intl.NumberFormat("en-US").format(value);
+}
+
+export default async function DashboardPage() {
+  let data: DashboardStats | null = null;
+  let error: string | null = null;
+
+  try {
+    data = await api.dashboard();
+  } catch (e) {
+    error = e instanceof Error ? e.message : "Failed to load dashboard";
+  }
+
+  if (error || !data) {
+    return (
+      <div className="p-6 space-y-6">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Dashboard</h1>
+          <p className="text-muted-foreground text-sm">
+            Medicare provider fraud detection overview
+          </p>
+        </div>
+        <Card>
+          <CardContent className="py-10 text-center text-muted-foreground">
+            <p>Unable to connect to API</p>
+            <p className="text-xs mt-1">{error}</p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const { total_providers, total_cases, risk_distribution, top_providers } =
+    data;
+
   return (
     <div className="p-6 space-y-6">
       <div>
@@ -21,7 +96,9 @@ export default function DashboardPage() {
             <Users className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">10,282</div>
+            <div className="text-2xl font-bold">
+              {formatNumber(total_providers)}
+            </div>
             <p className="text-xs text-muted-foreground">
               Medicare Part B providers
             </p>
@@ -34,7 +111,9 @@ export default function DashboardPage() {
             <AlertTriangle className="h-4 w-4 text-destructive" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-destructive">153</div>
+            <div className="text-2xl font-bold text-destructive">
+              {formatNumber(risk_distribution.high_risk)}
+            </div>
             <p className="text-xs text-muted-foreground">Score above 51</p>
           </CardContent>
         </Card>
@@ -45,8 +124,12 @@ export default function DashboardPage() {
             <Eye className="h-4 w-4 text-amber-500" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-amber-500">5,226</div>
-            <p className="text-xs text-muted-foreground">Score 31-50</p>
+            <div className="text-2xl font-bold text-amber-500">
+              {formatNumber(risk_distribution.review)}
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Score 31{"\u2013"}50
+            </p>
           </CardContent>
         </Card>
 
@@ -56,7 +139,9 @@ export default function DashboardPage() {
             <Activity className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">13,225</div>
+            <div className="text-2xl font-bold">
+              {formatNumber(total_cases)}
+            </div>
             <p className="text-xs text-muted-foreground">
               Service line cases analyzed
             </p>
@@ -64,31 +149,117 @@ export default function DashboardPage() {
         </Card>
       </div>
 
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">System Status</CardTitle>
-        </CardHeader>
-        <CardContent className="flex gap-3">
-          <Badge
-            variant="outline"
-            className="text-green-600 border-green-200 bg-green-50"
-          >
-            API Connected
-          </Badge>
-          <Badge
-            variant="outline"
-            className="text-green-600 border-green-200 bg-green-50"
-          >
-            Database OK
-          </Badge>
-          <Badge
-            variant="outline"
-            className="text-green-600 border-green-200 bg-green-50"
-          >
-            Graph OK
-          </Badge>
-        </CardContent>
-      </Card>
+      <div className="grid gap-4 lg:grid-cols-3">
+        <Card className="lg:col-span-2">
+          <CardHeader>
+            <CardTitle className="text-base">
+              Top 10 Highest-Risk Providers
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Provider</TableHead>
+                  <TableHead>State</TableHead>
+                  <TableHead className="text-right">Score</TableHead>
+                  <TableHead className="text-right">Est. Payment</TableHead>
+                  <TableHead>Risk</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {top_providers.map((p) => (
+                  <TableRow key={p.npi}>
+                    <TableCell>
+                      <Link
+                        href={`/providers/${p.npi}`}
+                        className="font-medium hover:underline"
+                      >
+                        {p.provider_name ?? p.npi}
+                      </Link>
+                      <div className="text-xs text-muted-foreground">
+                        {p.provider_type}
+                      </div>
+                    </TableCell>
+                    <TableCell>{p.state ?? "\u2014"}</TableCell>
+                    <TableCell className="text-right font-mono">
+                      {p.max_seed_risk_score ?? "\u2014"}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {formatCurrency(p.total_estimated_payment)}
+                    </TableCell>
+                    <TableCell>{riskBadge(p.risk_band)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Risk Distribution</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <RiskBar
+              label="High Risk"
+              count={risk_distribution.high_risk}
+              total={total_providers}
+              color="bg-red-500"
+              icon={<AlertTriangle className="h-4 w-4 text-red-500" />}
+            />
+            <RiskBar
+              label="Review"
+              count={risk_distribution.review}
+              total={total_providers}
+              color="bg-amber-500"
+              icon={<Eye className="h-4 w-4 text-amber-500" />}
+            />
+            <RiskBar
+              label="Stable"
+              count={risk_distribution.stable}
+              total={total_providers}
+              color="bg-green-500"
+              icon={<ShieldCheck className="h-4 w-4 text-green-500" />}
+            />
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+function RiskBar({
+  label,
+  count,
+  total,
+  color,
+  icon,
+}: {
+  label: string;
+  count: number;
+  total: number;
+  color: string;
+  icon: React.ReactNode;
+}) {
+  const pct = total > 0 ? (count / total) * 100 : 0;
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between text-sm">
+        <span className="flex items-center gap-1.5">
+          {icon}
+          {label}
+        </span>
+        <span className="font-mono text-muted-foreground">
+          {formatNumber(count)} ({pct.toFixed(1)}%)
+        </span>
+      </div>
+      <div className="h-2 rounded-full bg-muted">
+        <div
+          className={`h-full rounded-full ${color}`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
     </div>
   );
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,14 +1,11 @@
 import type {
-  Claim,
-  DashboardData,
+  ClaimListResponse,
+  DashboardStats,
   GraphResponse,
-  HeatmapEntry,
+  HeatmapResponse,
   HealthResponse,
-  PeerComparison,
-  ProviderDetail,
   ProviderListResponse,
   ScoreResult,
-  Signal,
 } from "@/types/api";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
@@ -24,7 +21,7 @@ async function fetchApi<T>(path: string): Promise<T> {
 export const api = {
   health: () => fetchApi<HealthResponse>("/health"),
 
-  dashboard: () => fetchApi<DashboardData>("/api/dashboard"),
+  dashboard: () => fetchApi<DashboardStats>("/api/dashboard"),
 
   providers: (params?: {
     limit?: number;
@@ -41,18 +38,12 @@ export const api = {
     );
   },
 
-  provider: (npi: string) => fetchApi<ProviderDetail>(`/api/providers/${npi}`),
-
-  signals: (npi: string) => fetchApi<Signal[]>(`/api/providers/${npi}/signals`),
-
-  peers: (npi: string) =>
-    fetchApi<PeerComparison[]>(`/api/providers/${npi}/peers`),
-
-  claims: (npi: string) => fetchApi<Claim[]>(`/api/providers/${npi}/claims`),
+  claims: (npi: string) =>
+    fetchApi<ClaimListResponse>(`/api/providers/${npi}/claims`),
 
   score: (npi: string) => fetchApi<ScoreResult>(`/api/score/${npi}`),
 
-  heatmap: () => fetchApi<HeatmapEntry[]>("/api/heatmap"),
+  heatmap: () => fetchApi<HeatmapResponse>("/api/dashboard/heatmap"),
 
   graph: (npi: string) => fetchApi<GraphResponse>(`/api/graph/${npi}`),
 };

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1,86 +1,89 @@
 export type RiskBand = "stable" | "review" | "high_risk";
 
-export interface Provider {
-  npi: string;
-  provider_name: string;
-  provider_type: string;
-  state: string;
-  city: string;
-  entity_code: string;
-  max_seed_risk_score: number;
-  risk_band: RiskBand;
-  service_line_count: number;
-  total_estimated_payment: number;
-  revoked_2026: number;
+export interface PaginationMeta {
+  total: number;
+  page: number;
+  per_page: number;
+  pages: number;
 }
 
-export interface ProviderDetail extends Provider {
-  enrolled_2025: number;
-  total_services: number;
-  total_benes: number;
-  unique_hcpcs_codes: number;
-  mean_submitted_charge: number;
-  mean_payment_amt: number;
-  service_hhi: number;
-  top_code_share: number;
+export interface ProviderSummary {
+  npi: string;
+  provider_name: string | null;
+  provider_type: string | null;
+  state: string | null;
+  city: string | null;
+  entity_code: string | null;
+  max_seed_risk_score: number | null;
+  risk_band: RiskBand | null;
+  service_line_count: number | null;
+  total_estimated_payment: number | null;
+  revoked_2026: number | null;
+}
+
+export interface ProviderListResponse {
+  data: ProviderSummary[];
+  meta: PaginationMeta;
+}
+
+export interface RiskDistribution {
+  high_risk: number;
+  review: number;
+  stable: number;
+}
+
+export interface DashboardStats {
+  total_providers: number;
+  total_cases: number;
+  risk_distribution: RiskDistribution;
+  top_providers: ProviderSummary[];
 }
 
 export interface Signal {
-  signal_id: string;
-  category: string;
   name: string;
+  category: string;
   direction: string;
-  value: number;
-  detail: string;
-  weight: number;
-}
-
-export interface PeerComparison {
-  npi: string;
-  provider_name: string;
-  provider_type: string;
-  state: string;
-  risk_score: number;
-  total_services: number;
-  total_payment: number;
-}
-
-export interface Claim {
-  case_id: string;
-  hcpcs_cd: string;
-  hcpcs_desc: string;
-  tot_srvcs: number;
-  tot_benes: number;
-  avg_submitted_charge: number;
-  avg_medicare_payment_amt: number;
-  seed_risk_score: number;
-  seed_case_label: string;
+  value: number | null;
+  threshold: number | null;
+  description: string;
 }
 
 export interface ScoreResult {
   npi: string;
-  provider_name: string;
-  composite_score: number;
+  risk_score: number;
+  legitimacy_score: number;
   risk_band: RiskBand;
   signals: Signal[];
+  narrative: string | null;
 }
 
-export interface DashboardData {
-  total_providers: number;
-  total_cases: number;
-  risk_distribution: {
-    high_risk: number;
-    review: number;
-    stable: number;
-  };
-  top_providers: Provider[];
+export interface Claim {
+  case_id: string;
+  npi: string;
+  hcpcs_cd: string;
+  hcpcs_desc: string | null;
+  tot_benes: number | null;
+  tot_srvcs: number | null;
+  avg_submitted_charge: number | null;
+  avg_medicare_payment_amt: number | null;
+  seed_risk_score: number | null;
+  seed_case_label: string | null;
+}
+
+export interface ClaimListResponse {
+  data: Claim[];
+  meta: PaginationMeta;
 }
 
 export interface HeatmapEntry {
   state: string;
   provider_count: number;
-  high_risk_count: number;
   avg_risk_score: number;
+  flagged_count: number;
+}
+
+export interface HeatmapResponse {
+  data: HeatmapEntry[];
 }
 
 export interface GraphNode {
@@ -108,11 +111,4 @@ export interface HealthResponse {
   database: string;
   graph: string;
   version: string;
-}
-
-export interface ProviderListResponse {
-  data: Provider[];
-  total: number;
-  page: number;
-  per_page: number;
 }


### PR DESCRIPTION
## Summary
- Rewrites dashboard page as async server component fetching live data from `GET /api/dashboard`
- Adds Top 10 highest-risk providers table with links to detail pages
- Adds risk distribution bar chart (high risk / review / stable with percentages)
- Updates TypeScript types and API client to match actual backend Pydantic schemas
- Graceful error state when API is unreachable

## Changes
- `frontend/src/types/api.ts` — rewritten to match backend schemas exactly (`ProviderSummary`, `DashboardStats`, `PaginationMeta`, etc.)
- `frontend/src/lib/api.ts` — updated imports and endpoint paths to match backend routes
- `frontend/src/app/page.tsx` — async server component with live data, top providers table, risk distribution bars

## Test plan
- [x] `npm run build` passes — `/` is now dynamic (server-rendered)
- [x] TypeScript compiles clean
- [ ] CI checks pass

Closes #59