### PR TITLE
feat(frontend): add risk gauge component (#44)

### DIFF
--- a/frontend/src/app/providers/[npi]/page.tsx
+++ b/frontend/src/app/providers/[npi]/page.tsx
@@ -6,6 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { api } from "@/lib/api";
 import { PeerChart } from "@/components/peer-chart";
+import { RiskGauge } from "@/components/risk-gauge";
 import { ScanButton } from "@/components/scan-button";
 import type { ProviderDetail, Signal } from "@/types/api";
 
@@ -155,12 +156,7 @@ export default async function ProviderDetailPage({
           </div>
         </div>
         <div className="flex items-center gap-3">
-          <div className="text-right">
-            <p className="text-xs text-muted-foreground">Risk Score</p>
-            <p className="text-3xl font-bold font-mono">
-              {provider.max_seed_risk_score ?? "\u2014"}
-            </p>
-          </div>
+          <RiskGauge score={provider.max_seed_risk_score} />
           {riskBadge(provider.risk_band, "lg")}
         </div>
       </div>

--- a/frontend/src/components/risk-gauge.tsx
+++ b/frontend/src/components/risk-gauge.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const ZONES = [
+  { max: 30, color: "hsl(142 71% 45%)", label: "Stable" },
+  { max: 50, color: "hsl(45 93% 47%)", label: "Review" },
+  { max: 100, color: "hsl(0 72% 51%)", label: "High Risk" },
+] as const;
+
+function scoreColor(score: number) {
+  for (const z of ZONES) {
+    if (score <= z.max) return z.color;
+  }
+  return ZONES[ZONES.length - 1].color;
+}
+
+export function RiskGauge({
+  score,
+  size = 120,
+}: {
+  score: number | null | undefined;
+  size?: number;
+}) {
+  const [animated, setAnimated] = useState(0);
+
+  useEffect(() => {
+    const target = score ?? 0;
+    const timer = setTimeout(() => setAnimated(target), 50);
+    return () => clearTimeout(timer);
+  }, [score]);
+
+  if (score == null) {
+    return (
+      <div
+        className="flex items-center justify-center rounded-full border-4 border-muted"
+        style={{ width: size, height: size }}
+      >
+        <span className="text-muted-foreground text-sm">N/A</span>
+      </div>
+    );
+  }
+
+  const pct = Math.min(Math.max(animated, 0), 100);
+  const angle = (pct / 100) * 360;
+  const color = scoreColor(pct);
+
+  return (
+    <div
+      className="relative flex items-center justify-center rounded-full"
+      style={{
+        width: size,
+        height: size,
+        background: `conic-gradient(${color} ${angle}deg, hsl(var(--muted)) ${angle}deg)`,
+        transition: "background 0.8s ease-out",
+      }}
+    >
+      <div
+        className="absolute rounded-full bg-background flex flex-col items-center justify-center"
+        style={{ width: size - 16, height: size - 16 }}
+      >
+        <span className="text-2xl font-bold font-mono leading-none">
+          {score}
+        </span>
+        <span className="text-[10px] text-muted-foreground">/ 100</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/scan-button.tsx
+++ b/frontend/src/components/scan-button.tsx
@@ -5,6 +5,7 @@ import { ScanLine, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { RiskGauge } from "@/components/risk-gauge";
 import type { ScoreResult, Signal } from "@/types/api";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
@@ -107,13 +108,8 @@ export function ScanButton({ npi }: { npi: string }) {
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-3">
-            <div className="grid grid-cols-2 gap-4">
-              <div>
-                <p className="text-xs text-muted-foreground">Risk Score</p>
-                <p className="text-2xl font-bold font-mono text-destructive">
-                  {result.risk_score}
-                </p>
-              </div>
+            <div className="flex items-center gap-6">
+              <RiskGauge score={result.risk_score} size={90} />
               <div>
                 <p className="text-xs text-muted-foreground">
                   Legitimacy Score


### PR DESCRIPTION
## Summary
- New `RiskGauge` client component using CSS `conic-gradient` for a donut-style gauge
- Three color zones: green (0-30 stable), yellow (31-50 review), red (51+ high risk)
- Animated on mount via delayed state update + CSS transition
- Integrated on provider detail page header (replaces plain text score)
- Added to scan result card in `ScanButton` component

Closes #44