### PR TITLE
feat(api): add claim simulation request/response schemas (#143)

### DIFF
--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -57,6 +57,40 @@ export interface ScoreResult {
   narrative: string | null;
 }
 
+export type Recommendation = "approve" | "review" | "deny";
+
+export interface ClaimSimulationRequest {
+  npi: string;
+  hcpcs_cd: string;
+  submitted_charge: number;
+  num_services: number;
+  num_benes: number;
+  place_of_service?: string;
+}
+
+export interface PeerComparisonStats {
+  metric: string;
+  provider_value: number;
+  peer_mean: number;
+  z_score: number;
+  percentile: number | null;
+  peer_count: number;
+}
+
+export interface ClaimSimulationResult {
+  npi: string;
+  hcpcs_cd: string;
+  risk_score: number;
+  risk_band: RiskBand;
+  recommendation: Recommendation;
+  signals: Signal[];
+  peer_comparisons: PeerComparisonStats[];
+  provider_name: string | null;
+  provider_type: string | null;
+  state: string | null;
+  narrative: string | null;
+}
+
 export interface Claim {
   case_id: string;
   npi: string;

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -21,6 +21,12 @@ class RiskBand(StrEnum):
     stable = "stable"
 
 
+class Recommendation(StrEnum):
+    approve = "approve"
+    review = "review"
+    deny = "deny"
+
+
 # ---------------------------------------------------------------------------
 # Pagination
 # ---------------------------------------------------------------------------
@@ -240,6 +246,53 @@ class ScoreResult(BaseModel):
     risk_band: RiskBand
     signals: list[Signal] = []
     narrative: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Claim Simulation schemas
+# ---------------------------------------------------------------------------
+
+
+class ClaimSimulationRequest(BaseModel):
+    """Input for real-time single-claim scoring."""
+
+    npi: str = Field(description="Provider NPI")
+    hcpcs_cd: str = Field(description="HCPCS procedure code")
+    submitted_charge: float = Field(gt=0, description="Submitted charge amount in USD")
+    num_services: int = Field(gt=0, description="Number of services on this claim")
+    num_benes: int = Field(gt=0, description="Number of beneficiaries")
+    place_of_service: str | None = Field(
+        default=None, description="Place of service code (optional)"
+    )
+
+
+class PeerComparisonStats(BaseModel):
+    """Provider value vs peer baseline for a single metric."""
+
+    metric: str = Field(description="e.g. submitted_charge, services_per_bene")
+    provider_value: float
+    peer_mean: float
+    z_score: float
+    percentile: float | None = Field(
+        default=None, ge=0, le=100, description="Provider percentile among peers"
+    )
+    peer_count: int = Field(description="Number of peers in comparison group")
+
+
+class ClaimSimulationResult(BaseModel):
+    """Output from real-time claim scoring."""
+
+    npi: str
+    hcpcs_cd: str
+    risk_score: int = Field(ge=0, le=100)
+    risk_band: RiskBand
+    recommendation: Recommendation
+    signals: list[Signal] = []
+    peer_comparisons: list[PeerComparisonStats] = []
+    provider_name: str | None = None
+    provider_type: str | None = None
+    state: str | None = None
+    narrative: str | None = Field(default=None, description="AI-generated verdict explanation")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `ClaimSimulationRequest` — single claim input: NPI + HCPCS + charge + services + benes
- `ClaimSimulationResult` — scoring output: risk score, band, recommendation (approve/review/deny), signals, peer comparisons, provider context, narrative
- `PeerComparisonStats` — provider value vs peer mean with z-score and percentile
- `Recommendation` enum: approve, review, deny
- Frontend TypeScript types mirror backend Pydantic schemas exactly

Closes #143