### PR TITLE
feat(ai): add text-to-SQL engine with query validation (#30)

### DIFF
--- a/src/ai/text_to_sql.py
+++ b/src/ai/text_to_sql.py
@@ -1,0 +1,162 @@
+"""Text-to-SQL engine: natural language → validated SQL → executed results.
+
+Accepts a natural language question, sends it to Claude with the schema prompt,
+validates the generated SQL (SELECT only, no mutations), executes it against
+PostgreSQL, and returns formatted results.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import time
+from typing import Any
+
+from psycopg import AsyncConnection
+
+from src.ai.bedrock import CHAT_MODEL, invoke
+from src.ai.prompts import build_text_to_sql_system_prompt
+
+logger = logging.getLogger(__name__)
+
+# Safety limits
+MAX_ROWS = 500
+QUERY_TIMEOUT_MS = 5000
+
+# Patterns that must never appear in generated SQL
+_FORBIDDEN_PATTERNS = re.compile(
+    r"\b(INSERT|UPDATE|DELETE|DROP|ALTER|CREATE|TRUNCATE|GRANT|REVOKE|EXEC|EXECUTE)\b",
+    re.IGNORECASE,
+)
+
+# Must start with SELECT or WITH (for CTEs)
+_ALLOWED_START = re.compile(r"^\s*(SELECT|WITH)\b", re.IGNORECASE)
+
+
+class SQLValidationError(Exception):
+    """Raised when generated SQL fails safety checks."""
+
+
+def validate_sql(sql: str) -> str:
+    """Validate and sanitize generated SQL. Returns cleaned SQL or raises."""
+    cleaned = sql.strip().rstrip(";").strip()
+
+    if not cleaned:
+        raise SQLValidationError("Empty SQL generated")
+
+    if cleaned.upper() == "UNANSWERABLE":
+        raise SQLValidationError("UNANSWERABLE")
+
+    if not _ALLOWED_START.match(cleaned):
+        raise SQLValidationError(f"SQL must start with SELECT or WITH, got: {cleaned[:50]}")
+
+    forbidden = _FORBIDDEN_PATTERNS.search(cleaned)
+    if forbidden:
+        raise SQLValidationError(f"Forbidden keyword: {forbidden.group()}")
+
+    # Strip any trailing semicolons and add LIMIT if missing
+    if not re.search(r"\bLIMIT\b", cleaned, re.IGNORECASE):
+        cleaned = f"{cleaned} LIMIT {MAX_ROWS}"
+
+    return cleaned
+
+
+async def text_to_sql(
+    question: str,
+    conn: AsyncConnection,
+    *,
+    model: str = CHAT_MODEL,
+) -> dict[str, Any]:
+    """Convert natural language question to SQL, execute, return results.
+
+    Returns dict with keys:
+        - answer: formatted text answer
+        - sql: the generated SQL query
+        - columns: list of column names
+        - rows: list of row dicts
+        - row_count: number of rows returned
+        - duration_ms: query execution time
+    """
+    system_prompt = build_text_to_sql_system_prompt()
+
+    # Ask Claude to generate SQL
+    response = await invoke(
+        messages=[{"role": "user", "content": question}],
+        system=system_prompt,
+        model=model,
+        max_tokens=512,
+        temperature=0.0,
+    )
+
+    raw_sql = response["text"].strip()
+
+    # Strip markdown code fences if present
+    if raw_sql.startswith("```"):
+        raw_sql = re.sub(r"^```(?:sql)?\s*", "", raw_sql)
+        raw_sql = re.sub(r"\s*```$", "", raw_sql)
+
+    sql = validate_sql(raw_sql)
+
+    # Execute with timeout
+    start = time.monotonic()
+    async with conn.cursor() as cur:
+        await cur.execute(f"SET statement_timeout = '{QUERY_TIMEOUT_MS}'")
+        await cur.execute(sql)
+        columns = [desc.name for desc in cur.description] if cur.description else []
+        raw_rows = await cur.fetchall()
+        await cur.execute("RESET statement_timeout")
+
+    duration_ms = int((time.monotonic() - start) * 1000)
+
+    rows = [dict(zip(columns, row)) for row in raw_rows]
+
+    # Build a text answer from the results
+    answer = _format_answer(question, columns, rows)
+
+    logger.info(
+        "text_to_sql question=%r rows=%d duration=%dms sql=%s",
+        question[:80],
+        len(rows),
+        duration_ms,
+        sql[:200],
+    )
+
+    return {
+        "answer": answer,
+        "sql": sql,
+        "columns": columns,
+        "rows": rows,
+        "row_count": len(rows),
+        "duration_ms": duration_ms,
+    }
+
+
+def _format_answer(question: str, columns: list[str], rows: list[dict[str, Any]]) -> str:
+    """Format query results into a human-readable text answer."""
+    if not rows:
+        return "No results found for your query."
+
+    if len(rows) == 1 and len(columns) == 1:
+        # Scalar result
+        val = rows[0][columns[0]]
+        return f"{_format_value(val)}"
+
+    if len(rows) == 1:
+        # Single row — describe each column
+        row = rows[0]
+        parts = [f"{col}: {_format_value(row[col])}" for col in columns]
+        return ", ".join(parts)
+
+    # Multiple rows — summarize
+    return f"Found {len(rows)} results."
+
+
+def _format_value(val: Any) -> str:
+    """Format a single value for display."""
+    if val is None:
+        return "N/A"
+    if isinstance(val, float):
+        if abs(val) >= 1000:
+            return f"{val:,.0f}"
+        return f"{val:.2f}"
+    return str(val)

--- a/tests/test_text_to_sql.py
+++ b/tests/test_text_to_sql.py
@@ -1,0 +1,114 @@
+"""Tests for text-to-SQL engine — validation and formatting."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.ai.text_to_sql import SQLValidationError, _format_answer, _format_value, validate_sql
+
+# ---------------------------------------------------------------------------
+# SQL validation tests
+# ---------------------------------------------------------------------------
+
+
+def test_validate_basic_select():
+    assert validate_sql("SELECT 1") == "SELECT 1 LIMIT 500"
+
+
+def test_validate_with_existing_limit():
+    sql = "SELECT * FROM provider_features LIMIT 10"
+    assert validate_sql(sql) == "SELECT * FROM provider_features LIMIT 10"
+
+
+def test_validate_with_cte():
+    sql = "WITH x AS (SELECT 1) SELECT * FROM x"
+    result = validate_sql(sql)
+    assert result.startswith("WITH x AS")
+    assert "LIMIT 500" in result
+
+
+def test_validate_strips_semicolons():
+    sql = "SELECT count(*) FROM provider_features;;;"
+    result = validate_sql(sql)
+    assert not result.endswith(";")
+
+
+def test_validate_strips_markdown_fences():
+    """validate_sql doesn't strip fences (text_to_sql does), but rejects if not SELECT."""
+    with pytest.raises(SQLValidationError, match="must start with SELECT"):
+        validate_sql("```sql\nSELECT 1\n```")
+
+
+def test_reject_empty():
+    with pytest.raises(SQLValidationError, match="Empty"):
+        validate_sql("")
+
+
+def test_reject_unanswerable():
+    with pytest.raises(SQLValidationError, match="UNANSWERABLE"):
+        validate_sql("UNANSWERABLE")
+
+
+@pytest.mark.parametrize(
+    "bad_sql",
+    [
+        "INSERT INTO provider_features VALUES ('x')",
+        "UPDATE provider_features SET state='XX'",
+        "DELETE FROM provider_features",
+        "DROP TABLE provider_features",
+        "ALTER TABLE provider_features ADD COLUMN x TEXT",
+        "CREATE TABLE evil (id INT)",
+        "TRUNCATE provider_features",
+        "GRANT ALL ON provider_features TO public",
+    ],
+)
+def test_reject_mutations(bad_sql: str):
+    with pytest.raises(SQLValidationError, match="Forbidden keyword|must start with SELECT"):
+        validate_sql(bad_sql)
+
+
+def test_reject_non_select_start():
+    with pytest.raises(SQLValidationError, match="must start with SELECT"):
+        validate_sql("EXPLAIN SELECT 1")
+
+
+# ---------------------------------------------------------------------------
+# Format tests
+# ---------------------------------------------------------------------------
+
+
+def test_format_value_none():
+    assert _format_value(None) == "N/A"
+
+
+def test_format_value_large_float():
+    assert _format_value(1234567.89) == "1,234,568"
+
+
+def test_format_value_small_float():
+    assert _format_value(3.14159) == "3.14"
+
+
+def test_format_value_string():
+    assert _format_value("hello") == "hello"
+
+
+def test_format_answer_no_results():
+    assert "No results" in _format_answer("q", [], [])
+
+
+def test_format_answer_scalar():
+    result = _format_answer("q", ["count"], [{"count": 42}])
+    assert "42" in result
+
+
+def test_format_answer_single_row():
+    result = _format_answer("q", ["name", "state"], [{"name": "Smith", "state": "FL"}])
+    assert "Smith" in result
+    assert "FL" in result
+
+
+def test_format_answer_multiple_rows():
+    rows = [{"id": 1}, {"id": 2}, {"id": 3}]
+    result = _format_answer("q", ["id"], rows)
+    assert "3 results" in result


### PR DESCRIPTION
## Summary
- `src/ai/text_to_sql.py` — NL question → Claude → SQL → validate → execute → format
- SQL safety: SELECT/WITH only, forbidden keyword regex, auto LIMIT 500, statement_timeout 5s
- Strips markdown fences, detects UNANSWERABLE, formats scalar/row/table results

Closes #30

## Test plan
- [x] 24 new tests in `tests/test_text_to_sql.py`
- [x] Full suite: 239 passed, 72% coverage
- [x] ruff + mypy clean