### PR TITLE
feat(ai): add risk narrative generator wired into scoring (#31)

### DIFF
--- a/src/ai/narrative.py
+++ b/src/ai/narrative.py
@@ -1,0 +1,93 @@
+"""Risk narrative generator — AI-powered investigation briefs.
+
+Takes structured scoring data (signals, risk score, provider context) and
+generates a concise human-readable narrative using Claude via Bedrock.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from src.ai.bedrock import NARRATIVE_MODEL, invoke
+from src.ai.prompts import NARRATIVE_SYSTEM_PROMPT
+
+logger = logging.getLogger(__name__)
+
+
+async def generate_narrative(
+    *,
+    npi: str,
+    risk_score: int,
+    risk_band: str,
+    signals: list[dict[str, Any]],
+    provider_name: str | None = None,
+    provider_type: str | None = None,
+    state: str | None = None,
+    recommendation: str | None = None,
+    peer_comparisons: list[dict[str, Any]] | None = None,
+) -> str | None:
+    """Generate a risk narrative from structured scoring data.
+
+    Returns the narrative string, or None if generation fails (non-fatal).
+    """
+    # Build a structured summary for Claude
+    risk_signals = [s for s in signals if s.get("direction") == "risk"]
+    legit_signals = [s for s in signals if s.get("direction") == "legitimacy"]
+
+    parts = [
+        f"Provider: {provider_name or 'Unknown'} (NPI: {npi})",
+        f"Type: {provider_type or 'Unknown'}",
+        f"State: {state or 'Unknown'}",
+        f"Risk Score: {risk_score}/100 (Band: {risk_band})",
+    ]
+
+    if recommendation:
+        parts.append(f"Recommendation: {recommendation.upper()}")
+
+    if risk_signals:
+        signal_lines = []
+        for s in risk_signals:
+            desc = s.get("description", s.get("name", "unknown"))
+            val = s.get("value")
+            if val is not None:
+                signal_lines.append(f"  - {desc} (value: {val})")
+            else:
+                signal_lines.append(f"  - {desc}")
+        parts.append("Risk Signals:\n" + "\n".join(signal_lines))
+
+    if legit_signals:
+        signal_lines = []
+        for s in legit_signals:
+            desc = s.get("description", s.get("name", "unknown"))
+            signal_lines.append(f"  - {desc}")
+        parts.append("Legitimacy Signals:\n" + "\n".join(signal_lines))
+
+    if peer_comparisons:
+        peer_lines = []
+        for p in peer_comparisons:
+            metric = p.get("metric", "unknown")
+            prov_val = p.get("provider_value", 0)
+            peer_mean = p.get("peer_mean", 0)
+            z = p.get("z_score", 0)
+            peer_lines.append(
+                f"  - {metric}: provider={prov_val}, peer_mean={peer_mean}, z={z:.1f}"
+            )
+        parts.append("Peer Comparisons:\n" + "\n".join(peer_lines))
+
+    user_message = "\n".join(parts)
+
+    try:
+        response = await invoke(
+            messages=[{"role": "user", "content": user_message}],
+            system=NARRATIVE_SYSTEM_PROMPT,
+            model=NARRATIVE_MODEL,
+            max_tokens=300,
+            temperature=0.3,
+        )
+        narrative: str = response["text"].strip()
+        logger.info("narrative generated for NPI=%s (%d chars)", npi, len(narrative))
+        return narrative
+    except Exception:
+        logger.exception("narrative generation failed for NPI=%s", npi)
+        return None

--- a/src/api/routes/score.py
+++ b/src/api/routes/score.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from psycopg import AsyncConnection
 from psycopg.rows import dict_row
 
+from src.ai.narrative import generate_narrative
 from src.api.deps import get_db
 from src.api.schemas import ScoreRequest, ScoreResult, Signal, risk_band_from_score
 from src.scoring.extract import FiredSignal
@@ -123,10 +124,20 @@ async def score_claim(
     risk_band = risk_band_from_score(card.risk_score)
     signals = [_fired_to_signal(fs) for fs in card.signals]
 
+    # 6. Generate AI narrative (non-blocking, non-fatal)
+    narrative = await generate_narrative(
+        npi=req.npi,
+        risk_score=card.risk_score,
+        risk_band=str(risk_band) if risk_band else "unknown",
+        signals=[s.model_dump() for s in signals],
+        provider_type=provider.get("provider_type"),
+    )
+
     return ScoreResult(
         npi=req.npi,
         risk_score=card.risk_score,
         legitimacy_score=card.legitimacy_score,
         risk_band=risk_band,  # type: ignore[arg-type]
         signals=signals,
+        narrative=narrative,
     )

--- a/src/api/routes/simulate.py
+++ b/src/api/routes/simulate.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from psycopg import AsyncConnection
 from psycopg.rows import dict_row
 
+from src.ai.narrative import generate_narrative
 from src.api.deps import get_db
 from src.api.schemas import (
     ClaimSimulationRequest,
@@ -181,6 +182,19 @@ async def simulate_claim(
     recommendation = _RISK_TO_RECOMMENDATION.get(risk_band, Recommendation.review)
     signals = [_fired_to_signal(fs) for fs in card.signals]
 
+    # 5. Generate AI narrative (non-blocking, non-fatal)
+    narrative = await generate_narrative(
+        npi=req.npi,
+        risk_score=card.risk_score,
+        risk_band=str(risk_band) if risk_band else "unknown",
+        signals=[s.model_dump() for s in signals],
+        provider_name=provider.get("provider_name"),
+        provider_type=provider.get("provider_type"),
+        state=provider.get("state"),
+        recommendation=recommendation,
+        peer_comparisons=[p.model_dump() for p in peer_comparisons],
+    )
+
     return ClaimSimulationResult(
         npi=req.npi,
         hcpcs_cd=req.hcpcs_cd,
@@ -192,4 +206,5 @@ async def simulate_claim(
         provider_name=provider.get("provider_name"),
         provider_type=provider.get("provider_type"),
         state=provider.get("state"),
+        narrative=narrative,
     )

--- a/tests/test_narrative.py
+++ b/tests/test_narrative.py
@@ -1,0 +1,108 @@
+"""Tests for risk narrative generator."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from src.ai.narrative import generate_narrative
+
+
+@pytest.mark.asyncio
+async def test_generate_narrative_success():
+    mock_response = {
+        "text": "This provider shows elevated risk due to revocation status.",
+        "input_tokens": 200,
+        "output_tokens": 30,
+        "stop_reason": "end_turn",
+    }
+
+    with patch("src.ai.narrative.invoke", return_value=mock_response):
+        result = await generate_narrative(
+            npi="1821387911",
+            risk_score=88,
+            risk_band="high_risk",
+            signals=[
+                {
+                    "name": "revoked_provider",
+                    "direction": "risk",
+                    "description": "Provider revoked",
+                },
+                {"name": "large_panel", "direction": "legitimacy", "description": "Large panel"},
+            ],
+            provider_name="Test Provider",
+            provider_type="Internal Medicine",
+            state="FL",
+        )
+
+    assert result is not None
+    assert "revocation" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_generate_narrative_with_peer_comparisons():
+    mock_response = {
+        "text": "Provider charges are 4x peer average.",
+        "input_tokens": 300,
+        "output_tokens": 20,
+        "stop_reason": "end_turn",
+    }
+
+    with patch("src.ai.narrative.invoke", return_value=mock_response) as mock_invoke:
+        result = await generate_narrative(
+            npi="1234567890",
+            risk_score=60,
+            risk_band="high_risk",
+            signals=[],
+            peer_comparisons=[
+                {
+                    "metric": "submitted_charge",
+                    "provider_value": 400,
+                    "peer_mean": 100,
+                    "z_score": 3.5,
+                },
+            ],
+        )
+
+    assert result is not None
+    # Verify peer data was included in the prompt
+    call_args = mock_invoke.call_args
+    user_msg = call_args.kwargs["messages"][0]["content"]
+    assert "submitted_charge" in user_msg
+    assert "400" in user_msg
+
+
+@pytest.mark.asyncio
+async def test_generate_narrative_handles_failure():
+    with patch("src.ai.narrative.invoke", side_effect=RuntimeError("Bedrock down")):
+        result = await generate_narrative(
+            npi="1234567890",
+            risk_score=50,
+            risk_band="review",
+            signals=[],
+        )
+
+    assert result is None  # non-fatal
+
+
+@pytest.mark.asyncio
+async def test_generate_narrative_includes_recommendation():
+    mock_response = {
+        "text": "DENY recommendation issued.",
+        "input_tokens": 100,
+        "output_tokens": 10,
+        "stop_reason": "end_turn",
+    }
+
+    with patch("src.ai.narrative.invoke", return_value=mock_response) as mock_invoke:
+        await generate_narrative(
+            npi="1234567890",
+            risk_score=80,
+            risk_band="high_risk",
+            signals=[],
+            recommendation="deny",
+        )
+
+    user_msg = mock_invoke.call_args.kwargs["messages"][0]["content"]
+    assert "DENY" in user_msg


### PR DESCRIPTION
## Summary
- `src/ai/narrative.py` — takes structured ScoreResult (signals, z-scores, peer data) → Claude Sonnet 4.6 generates concise investigation brief
- Wired into both `POST /api/score` and `POST /api/claims/simulate` — populates the `narrative` field
- Non-fatal: if Bedrock fails, scoring still returns normally with `narrative: null`

Closes #31

## Test plan
- [x] 4 new tests in `tests/test_narrative.py` (mock-based)
- [x] Full suite: 243 passed, 73% coverage
- [x] ruff + mypy clean