### PR TITLE
fix(ai): harden AI pipeline — readonly pool, history, logging (#32)

### DIFF
--- a/src/ai/narrative.py
+++ b/src/ai/narrative.py
@@ -89,5 +89,10 @@ async def generate_narrative(
         logger.info("narrative generated for NPI=%s (%d chars)", npi, len(narrative))
         return narrative
     except Exception:
-        logger.exception("narrative generation failed for NPI=%s", npi)
+        logger.exception(
+            "narrative generation failed for NPI=%s risk_score=%d band=%s",
+            npi,
+            risk_score,
+            risk_band,
+        )
         return None

--- a/src/ai/text_to_sql.py
+++ b/src/ai/text_to_sql.py
@@ -65,6 +65,7 @@ async def text_to_sql(
     question: str,
     conn: AsyncConnection,
     *,
+    history: list[dict[str, str]] | None = None,
     model: str = CHAT_MODEL,
 ) -> dict[str, Any]:
     """Convert natural language question to SQL, execute, return results.
@@ -79,9 +80,15 @@ async def text_to_sql(
     """
     system_prompt = build_text_to_sql_system_prompt()
 
+    # Build messages with conversation history for context
+    messages: list[dict[str, str]] = []
+    if history:
+        messages.extend(history[-6:])  # last 3 turns max to limit tokens
+    messages.append({"role": "user", "content": question})
+
     # Ask Claude to generate SQL
     response = await invoke(
-        messages=[{"role": "user", "content": question}],
+        messages=messages,
         system=system_prompt,
         model=model,
         max_tokens=512,

--- a/src/api/deps.py
+++ b/src/api/deps.py
@@ -11,20 +11,33 @@ DATABASE_URL = os.environ.get(
     "DATABASE_URL",
     f"postgresql://cms:cms_local_dev@{FORGE_HOST}:30432/cms_fraud",
 )
+DATABASE_URL_READONLY = os.environ.get(
+    "DATABASE_URL_READONLY",
+    f"postgresql://cms_readonly:cms_readonly_dev@{FORGE_HOST}:30432/cms_fraud",
+)
 
 pool: AsyncConnectionPool | None = None
+readonly_pool: AsyncConnectionPool | None = None
 
 
 async def open_pool() -> AsyncConnectionPool:
-    global pool
+    global pool, readonly_pool
     pool = AsyncConnectionPool(conninfo=DATABASE_URL, min_size=2, max_size=10, open=False)
     await pool.open()
     await pool.wait()
+    readonly_pool = AsyncConnectionPool(
+        conninfo=DATABASE_URL_READONLY, min_size=1, max_size=5, open=False
+    )
+    await readonly_pool.open()
+    await readonly_pool.wait()
     return pool
 
 
 async def close_pool() -> None:
-    global pool
+    global pool, readonly_pool
+    if readonly_pool:
+        await readonly_pool.close()
+        readonly_pool = None
     if pool:
         await pool.close()
         pool = None
@@ -35,4 +48,12 @@ async def get_db():
     if pool is None:
         raise RuntimeError("Database pool not initialized — app lifespan not started")
     async with pool.connection() as conn:
+        yield conn
+
+
+async def get_readonly_db():
+    """FastAPI dependency — yields a READ-ONLY connection for AI chat queries."""
+    if readonly_pool is None:
+        raise RuntimeError("Readonly pool not initialized — app lifespan not started")
+    async with readonly_pool.connection() as conn:
         yield conn

--- a/src/api/routes/chat.py
+++ b/src/api/routes/chat.py
@@ -13,7 +13,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from psycopg import AsyncConnection
 
 from src.ai.text_to_sql import SQLValidationError, text_to_sql
-from src.api.deps import get_db
+from src.api.deps import get_readonly_db
 from src.api.schemas import ChatRequest, ChatResponse
 
 logger = logging.getLogger(__name__)
@@ -37,15 +37,17 @@ def _serialize_row(row: dict) -> dict[str, object]:
 @router.post("", response_model=ChatResponse)
 async def chat(
     req: ChatRequest,
-    conn: AsyncConnection = Depends(get_db),
+    conn: AsyncConnection = Depends(get_readonly_db),
 ) -> ChatResponse:
     """Answer a natural language question about the CMS data.
 
     Routes the question through text-to-SQL: generates SQL via Claude,
     validates it, executes against PostgreSQL, and returns results.
     """
+    history = [{"role": m.role, "content": m.content} for m in req.history] or None
+
     try:
-        result = await text_to_sql(req.message, conn)
+        result = await text_to_sql(req.message, conn, history=history)
     except SQLValidationError as e:
         if "UNANSWERABLE" in str(e):
             return ChatResponse(

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -8,7 +8,7 @@ import pytest
 
 from src.ai.text_to_sql import SQLValidationError
 from src.api.routes.chat import _serialize_row, chat
-from src.api.schemas import ChatRequest
+from src.api.schemas import ChatMessage, ChatRequest
 
 # ---------------------------------------------------------------------------
 # Serialization tests
@@ -110,3 +110,33 @@ async def test_chat_internal_error():
             await chat(req, conn=AsyncMock())
 
     assert exc_info.value.status_code == 500
+
+
+@pytest.mark.asyncio
+async def test_chat_passes_history():
+    """Verify conversation history is forwarded to text_to_sql."""
+    mock_result = {
+        "answer": "5",
+        "sql": "SELECT count(*) FROM provider_features WHERE state = 'FL'",
+        "columns": ["count"],
+        "rows": [{"count": 5}],
+        "row_count": 1,
+        "duration_ms": 10,
+    }
+
+    with patch(
+        "src.api.routes.chat.text_to_sql", new_callable=AsyncMock, return_value=mock_result
+    ) as mock_t2s:
+        req = ChatRequest(
+            message="What about Florida?",
+            history=[
+                ChatMessage(role="user", content="How many high-risk providers in Texas?"),
+                ChatMessage(role="assistant", content="There are 12."),
+            ],
+        )
+        await chat(req, conn=AsyncMock())
+
+    _, kwargs = mock_t2s.call_args
+    assert kwargs["history"] is not None
+    assert len(kwargs["history"]) == 2
+    assert kwargs["history"][0]["role"] == "user"


### PR DESCRIPTION
## Summary
- Add `readonly_pool` + `get_readonly_db()` dependency so chat text-to-SQL runs on a SELECT-only connection
- Pass conversation history (last 3 turns) to text-to-SQL for follow-up question context
- Improve narrative error logging with risk_score and band for traceability
- Add test for history passthrough

## Test plan
- [x] All 252 tests passing
- [x] ruff lint + format clean
- [x] mypy clean

Closes #32