### PR TITLE
feat(frontend): add AI chat sidebar panel (#47)

### DIFF
--- a/frontend/src/components/chat-panel.tsx
+++ b/frontend/src/components/chat-panel.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Loader2, MessageSquare, SendHorizonal } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import type { ChatMessage, ChatResponse } from "@/types/api";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
+interface DisplayMessage {
+  role: "user" | "assistant";
+  content: string;
+  sql?: string | null;
+  row_count?: number;
+  duration_ms?: number;
+}
+
+const SUGGESTIONS = [
+  "How many high-risk providers are there?",
+  "Top 5 providers by total payment",
+  "Which states have the most flagged providers?",
+];
+
+export function ChatPanel() {
+  const [open, setOpen] = useState(false);
+  const [messages, setMessages] = useState<DisplayMessage[]>([]);
+  const [input, setInput] = useState("");
+  const [loading, setLoading] = useState(false);
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  const sendMessage = useCallback(
+    async (text: string) => {
+      if (!text.trim() || loading) return;
+
+      const userMsg: DisplayMessage = { role: "user", content: text.trim() };
+      setMessages((prev) => [...prev, userMsg]);
+      setInput("");
+      setLoading(true);
+
+      // Build history from previous messages (role + content only)
+      const history: ChatMessage[] = messages.map((m) => ({
+        role: m.role,
+        content: m.content,
+      }));
+
+      try {
+        const res = await fetch(`${API_BASE}/api/chat`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ message: text.trim(), history }),
+        });
+
+        if (!res.ok) {
+          const detail = await res.json().catch(() => null);
+          throw new Error(detail?.detail ?? `Request failed: ${res.status}`);
+        }
+
+        const data: ChatResponse = await res.json();
+        setMessages((prev) => [
+          ...prev,
+          {
+            role: "assistant",
+            content: data.answer,
+            sql: data.sql,
+            row_count: data.row_count,
+            duration_ms: data.duration_ms,
+          },
+        ]);
+      } catch (e) {
+        setMessages((prev) => [
+          ...prev,
+          {
+            role: "assistant",
+            content:
+              e instanceof Error
+                ? e.message
+                : "Something went wrong. Try rephrasing your question.",
+          },
+        ]);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [loading, messages],
+  );
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    sendMessage(input);
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger
+        render={
+          <Button
+            variant="ghost"
+            size="sm"
+            className="w-full justify-start gap-2 text-muted-foreground"
+          />
+        }
+      >
+        <MessageSquare className="h-4 w-4" />
+        Ask AI
+      </SheetTrigger>
+
+      <SheetContent side="right" className="flex flex-col sm:max-w-md">
+        <SheetHeader className="border-b pb-3">
+          <SheetTitle>Ask Argus AI</SheetTitle>
+          <p className="text-xs text-muted-foreground">
+            Ask questions about providers, claims, risk scores, and billing
+            patterns.
+          </p>
+        </SheetHeader>
+
+        {/* Messages */}
+        <ScrollArea className="flex-1 min-h-0">
+          <div className="space-y-3 p-4">
+            {messages.length === 0 && (
+              <div className="space-y-2 pt-8">
+                <p className="text-sm text-muted-foreground text-center">
+                  Try a question:
+                </p>
+                {SUGGESTIONS.map((s) => (
+                  <button
+                    key={s}
+                    type="button"
+                    className="block w-full text-left text-sm px-3 py-2 rounded-md border hover:bg-muted transition-colors"
+                    onClick={() => sendMessage(s)}
+                  >
+                    {s}
+                  </button>
+                ))}
+              </div>
+            )}
+
+            {messages.map((msg, i) => (
+              <div
+                key={i}
+                className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}
+              >
+                <div
+                  className={`max-w-[85%] rounded-lg px-3 py-2 text-sm ${
+                    msg.role === "user"
+                      ? "bg-primary text-primary-foreground"
+                      : "bg-muted"
+                  }`}
+                >
+                  <p className="whitespace-pre-wrap">{msg.content}</p>
+                  {msg.sql && (
+                    <details className="mt-2">
+                      <summary className="text-xs opacity-70 cursor-pointer">
+                        SQL ({msg.row_count} rows, {msg.duration_ms}ms)
+                      </summary>
+                      <pre className="mt-1 text-xs bg-background/50 rounded p-2 overflow-x-auto">
+                        {msg.sql}
+                      </pre>
+                    </details>
+                  )}
+                </div>
+              </div>
+            ))}
+
+            {loading && (
+              <div className="flex justify-start">
+                <div className="bg-muted rounded-lg px-3 py-2">
+                  <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                </div>
+              </div>
+            )}
+
+            <div ref={bottomRef} />
+          </div>
+        </ScrollArea>
+
+        {/* Input */}
+        <form
+          onSubmit={handleSubmit}
+          className="border-t p-3 flex items-center gap-2"
+        >
+          <Input
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="Ask about providers, claims, risk..."
+            disabled={loading}
+            className="flex-1"
+          />
+          <Button type="submit" size="icon" disabled={loading || !input.trim()}>
+            <SendHorizonal className="h-4 w-4" />
+          </Button>
+        </form>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/frontend/src/components/sidebar.tsx
+++ b/frontend/src/components/sidebar.tsx
@@ -12,6 +12,7 @@ import {
   FlaskConical,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { ChatPanel } from "@/components/chat-panel";
 
 const navItems = [
   { href: "/", label: "Dashboard", icon: LayoutDashboard },
@@ -54,9 +55,10 @@ export function Sidebar() {
           );
         })}
       </nav>
-      <div className="px-4 py-3 border-t text-xs text-muted-foreground">
-        v0.1.0
+      <div className="px-2 py-2 border-t">
+        <ChatPanel />
       </div>
+      <div className="px-4 py-2 text-xs text-muted-foreground">v0.1.0</div>
     </aside>
   );
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,6 @@
 import type {
+  ChatRequest,
+  ChatResponse,
   ClaimListResponse,
   ClaimSimulationRequest,
   ClaimSimulationResult,
@@ -105,4 +107,7 @@ export const api = {
       "/api/claims/simulate",
       req,
     ),
+
+  chat: (req: ChatRequest) =>
+    postApi<ChatRequest, ChatResponse>("/api/chat", req),
 };

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -211,6 +211,25 @@ export interface FairnessReport {
   disparate_impact_ratio: number | null;
 }
 
+export interface ChatMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
+export interface ChatRequest {
+  message: string;
+  history: ChatMessage[];
+}
+
+export interface ChatResponse {
+  answer: string;
+  sql: string | null;
+  columns: string[];
+  rows: Record<string, unknown>[];
+  row_count: number;
+  duration_ms: number;
+}
+
 export interface HealthResponse {
   status: string;
   database: string;


### PR DESCRIPTION
## Summary
- New `ChatPanel` component: slide-out Sheet triggered from sidebar "Ask AI" button
- Users type natural language questions, responses include answer + collapsible SQL details
- Conversation history sent to `/api/chat` for multi-turn follow-ups
- Suggestion chips shown on empty state for discoverability
- Types (`ChatMessage`, `ChatRequest`, `ChatResponse`) and `api.chat()` added

## Test plan
- [x] `npm run build` passes (Next.js 16 production build clean)
- [x] Manual: Sheet opens from sidebar, suggestions clickable, messages render correctly
- [x] Backend: 252 tests passing, all CI gates green

Closes #47