### PR TITLE
test(perf): add k6 load test for API endpoints (#169)

### DIFF
--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -1,0 +1,30 @@
+# Load Testing
+
+## Prerequisites
+
+Install [k6](https://k6.io/docs/get-started/installation/):
+
+```bash
+brew install k6
+```
+
+## Run
+
+```bash
+# Against live deployment
+k6 run tests/load/load_test.js
+
+# Against local dev server
+k6 run --env BASE_URL=http://localhost:8000 tests/load/load_test.js
+```
+
+## Test Profile
+
+- Ramp: 0 -> 10 VUs (15s) -> 50 VUs (15s) -> hold 50 VUs (60s) -> 0 (10s)
+- Total duration: ~100 seconds
+- Endpoint mix: dashboard 30%, providers 25%, provider detail 20%, score 15%, fairness 10%
+
+## Thresholds
+
+- p95 response time < 2000ms
+- Error rate < 5%

--- a/tests/load/load_test.js
+++ b/tests/load/load_test.js
@@ -1,0 +1,98 @@
+/**
+ * k6 load test for CMS Fraud Detection API.
+ *
+ * Usage:
+ *   k6 run tests/load/load_test.js
+ *   k6 run --env BASE_URL=https://argus.precise-lab.com tests/load/load_test.js
+ *
+ * Stages: ramp to 50 VUs over 30s, hold 60s, ramp down 10s.
+ */
+
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { Rate, Trend } from "k6/metrics";
+
+const BASE_URL = __ENV.BASE_URL || "https://argus.precise-lab.com";
+
+// Custom metrics
+const errorRate = new Rate("errors");
+const dashboardDuration = new Trend("dashboard_duration", true);
+const providersDuration = new Trend("providers_duration", true);
+const providerDetailDuration = new Trend("provider_detail_duration", true);
+const scoreDuration = new Trend("score_duration", true);
+const fairnessDuration = new Trend("fairness_duration", true);
+
+// Sample NPIs for provider detail requests (from the demo dataset)
+const SAMPLE_NPIS = [
+  "1821387911",
+  "1003000126",
+  "1003000142",
+  "1003000167",
+  "1003000175",
+];
+
+export const options = {
+  stages: [
+    { duration: "15s", target: 10 }, // warm up
+    { duration: "15s", target: 50 }, // ramp to peak
+    { duration: "60s", target: 50 }, // hold at peak
+    { duration: "10s", target: 0 }, // ramp down
+  ],
+  thresholds: {
+    http_req_duration: ["p(95)<2000"], // p95 < 2s
+    errors: ["rate<0.05"], // error rate < 5%
+  },
+};
+
+export default function () {
+  const scenario = Math.random();
+
+  if (scenario < 0.3) {
+    // 30% — Dashboard (heaviest query, aggregation)
+    const res = http.get(`${BASE_URL}/api/dashboard`);
+    dashboardDuration.add(res.timings.duration);
+    check(res, { "dashboard 200": (r) => r.status === 200 });
+    errorRate.add(res.status !== 200);
+  } else if (scenario < 0.55) {
+    // 25% — Provider list with search
+    const res = http.get(
+      `${BASE_URL}/api/providers?limit=20&offset=0&risk_band=high_risk`,
+    );
+    providersDuration.add(res.timings.duration);
+    check(res, { "providers 200": (r) => r.status === 200 });
+    errorRate.add(res.status !== 200);
+  } else if (scenario < 0.75) {
+    // 20% — Provider detail (random NPI)
+    const npi = SAMPLE_NPIS[Math.floor(Math.random() * SAMPLE_NPIS.length)];
+    const res = http.get(`${BASE_URL}/api/providers/${npi}`);
+    providerDetailDuration.add(res.timings.duration);
+    check(res, { "provider detail 2xx": (r) => r.status < 300 });
+    errorRate.add(res.status >= 300);
+  } else if (scenario < 0.9) {
+    // 15% — Score endpoint (simulate scoring)
+    const payload = JSON.stringify({
+      npi: "1821387911",
+      hcpcs_cd: "99213",
+      place_of_service: "O",
+      tot_benes: 150,
+      tot_srvcs: 500,
+      avg_submitted_charge: 120.0,
+      avg_medicare_allowed_amt: 80.0,
+      avg_medicare_payment_amt: 65.0,
+    });
+    const res = http.post(`${BASE_URL}/api/score`, payload, {
+      headers: { "Content-Type": "application/json" },
+    });
+    scoreDuration.add(res.timings.duration);
+    check(res, { "score 200": (r) => r.status === 200 });
+    errorRate.add(res.status !== 200);
+  } else {
+    // 10% — Fairness endpoint
+    const res = http.get(`${BASE_URL}/api/fairness`);
+    fairnessDuration.add(res.timings.duration);
+    check(res, { "fairness 200": (r) => r.status === 200 });
+    errorRate.add(res.status !== 200);
+  }
+
+  sleep(0.5 + Math.random() * 1.5); // 0.5-2s think time
+}


### PR DESCRIPTION
## Summary
- k6 load test targeting 5 API endpoints with realistic traffic distribution
- Ramps to 50 concurrent users, holds for 60s
- Thresholds: p95 < 2s, error rate < 5%
- Endpoint mix: dashboard 30%, providers 25%, detail 20%, score 15%, fairness 10%

Closes #169

## Test plan
- [x] k6 script syntax valid
- [ ] Run against live deployment and document results (separate step)