### PR TITLE
fix(workflow): allow case actions on simulated claims (#149)

### DIFF
--- a/frontend/src/components/simulate-result.tsx
+++ b/frontend/src/components/simulate-result.tsx
@@ -216,7 +216,7 @@ export function SimulateResult({ result }: { result: ClaimSimulationResult }) {
           <CardTitle className="text-sm">Analyst Decision</CardTitle>
         </CardHeader>
         <CardContent>
-          <CaseActions caseId={`${result.npi}_${result.hcpcs_cd}`} />
+          <CaseActions caseId={`${result.npi}|${result.hcpcs_cd}|O`} />
           <div className="mt-4 pt-3 border-t">
             <Link
               href={`/providers/${result.npi}`}

--- a/src/api/routes/cases.py
+++ b/src/api/routes/cases.py
@@ -32,29 +32,34 @@ async def record_action(
     req: CaseActionRequest,
     conn: AsyncConnection = Depends(get_db),
 ) -> CaseActionResponse:
-    """Record an analyst action on a case."""
-    # Verify the case exists
+    """Record an analyst action on a case.
+
+    Works for both real cases (in provider_service_cases) and simulated
+    claims where the case_id is constructed as ``npi|hcpcs|pos``.
+    """
     async with conn.cursor() as cur:
+        # Try to resolve NPI from the cases table first
         await cur.execute(
-            "SELECT 1 FROM provider_service_cases WHERE case_id = %s",
+            "SELECT npi FROM provider_service_cases WHERE case_id = %s",
             (case_id,),
         )
-        if not await cur.fetchone():
-            raise HTTPException(status_code=404, detail=f"Case {case_id} not found")
+        row = await cur.fetchone()
+        npi = row[0] if row else case_id.split("|")[0]
+
+        if not npi:
+            raise HTTPException(status_code=400, detail="Cannot resolve NPI from case_id")
 
         await cur.execute(
             """
             INSERT INTO case_actions (case_id, npi, action, notes)
-            SELECT %s, npi, %s, %s
-            FROM provider_service_cases
-            WHERE case_id = %s
+            VALUES (%s, %s, %s, %s)
             RETURNING id
             """,
-            (case_id, req.action.value, req.notes, case_id),
+            (case_id, npi, req.action.value, req.notes),
         )
         await conn.commit()
 
-    logger.info("Case %s action=%s", case_id, req.action.value)
+    logger.info("Case %s npi=%s action=%s", case_id, npi, req.action.value)
 
     return CaseActionResponse(
         case_id=case_id,

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from fastapi import HTTPException
 
 from src.api.routes.cases import list_actions, list_pending, record_action
 from src.api.schemas import CaseAction, CaseActionRequest
@@ -45,9 +44,10 @@ def _mock_conn(rows, description=None):
 
 @pytest.mark.asyncio
 async def test_record_action_success():
-    conn, cur = _mock_conn((1,))
-    # First fetchone returns case exists, second returns insert id
-    cur.fetchone = AsyncMock(side_effect=[(1,), (42,)])
+    """Real case — NPI resolved from provider_service_cases."""
+    conn, cur = _mock_conn(None)
+    # First fetchone returns NPI from DB, second returns insert id
+    cur.fetchone = AsyncMock(side_effect=[("1234567890",), (42,)])
     req = CaseActionRequest(action=CaseAction.flagged, notes="Suspicious billing")
 
     result = await record_action("case-001", req, conn)
@@ -58,23 +58,26 @@ async def test_record_action_success():
 
 
 @pytest.mark.asyncio
-async def test_record_action_case_not_found():
+async def test_record_action_simulated_case():
+    """Simulated case — NPI extracted from pipe-delimited case_id."""
     conn, cur = _mock_conn(None)
-    cur.fetchone = AsyncMock(return_value=None)
+    # DB lookup returns None (case not in provider_service_cases)
+    cur.fetchone = AsyncMock(side_effect=[None, (1,)])
     req = CaseActionRequest(action=CaseAction.approved)
 
-    with pytest.raises(HTTPException) as exc_info:
-        await record_action("nonexistent", req, conn)
+    result = await record_action("1760461826|99215|O", req, conn)
 
-    assert exc_info.value.status_code == 404
+    assert result.case_id == "1760461826|99215|O"
+    assert result.action == CaseAction.approved
+    assert "APPROVED" in result.message
 
 
 @pytest.mark.asyncio
 async def test_record_action_all_types():
     """Verify all action types are accepted."""
     for action in CaseAction:
-        conn, cur = _mock_conn((1,))
-        cur.fetchone = AsyncMock(side_effect=[(1,), (1,)])
+        conn, cur = _mock_conn(None)
+        cur.fetchone = AsyncMock(side_effect=[("1234567890",), (1,)])
         req = CaseActionRequest(action=action)
         result = await record_action("case-001", req, conn)
         assert result.action == action


### PR DESCRIPTION
## Summary

Self-review found that the `record_action` endpoint required cases to exist in `provider_service_cases`, which breaks for simulated claims (hypothetical, not in DB).

**Fix**: Extract NPI from the pipe-delimited `case_id` (`npi|hcpcs|pos`) when the case isn't found in `provider_service_cases`. Also fixes the case_id format in `simulate-result.tsx` (was `_` delimiter, now `|`).

- Backend: fallback NPI resolution via `case_id.split("|")[0]`
- Frontend: `simulate-result.tsx` case_id uses correct `npi|hcpcs|O` format
- Tests: replaced 404 test with simulated case test, 9/9 passing

Closes #149

## Test plan
- [x] `pytest tests/test_cases.py` — 9 passed
- [x] `ruff check` + `mypy` — clean
- [x] Full suite — 265 passed