### PR TITLE
ci(copilot): add coding agent setup and project instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,53 @@
+# Copilot Instructions — CMS Fraud Detection (Argus)
+
+## Project
+
+Proactive CMS provider fraud detection with explainable AI. Identifies anomalous Medicare billing patterns using peer comparison, risk scoring, and AI-generated narratives.
+
+## Stack
+
+- **API**: FastAPI + async psycopg pool (`src/api/`)
+- **Pipeline**: Polars-based feature engineering (`src/pipeline/`)
+- **AI Layer**: AWS Bedrock Claude for text-to-SQL and risk narratives (`src/ai/`)
+- **DB**: PostgreSQL 16 (provider_features: 63 columns, provider_service_cases: case-level)
+- **Graph**: Neo4j 5 for network risk signals
+- **Frontend**: Next.js 16 + Tailwind v4 + shadcn/ui + Recharts
+- **Python**: 3.12+, type-checked with mypy, linted with ruff
+
+## Conventions
+
+- **Commits**: `type(scope): description (#N)` — conventional commits, present tense
+- **Branches**: `<type>/<issue-number>-<description>`
+- **PRs**: Must include `Closes #N` in body
+- **Risk bands**: 0-30 stable, 31-50 review, 51+ high_risk (use StrEnum `RiskBand`)
+- **Naming**: kebab-case dirs/files, PascalCase classes, snake_case functions
+- **Tests**: pytest + pytest-asyncio, `asyncio_mode = "auto"`
+
+## Code Style
+
+- Pydantic v2 models for all API schemas (`src/api/schemas.py`)
+- Use `polars` for dataframes, never pandas
+- SQL queries use parameterized `$1` placeholders (psycopg), never f-strings
+- Async everywhere in the API layer — no sync DB calls
+- Keep functions focused; prefer flat logic over deep nesting
+
+## Security
+
+- Text-to-SQL has guardrails: block UNION, subqueries, pg_sleep, comments
+- All user inputs validated via Pydantic before reaching DB
+- No hardcoded credentials — use environment variables
+- Healthcare data context: treat all provider/claims data as sensitive
+
+## Testing
+
+- Run full CI locally: `ruff check`, `ruff format --check`, `mypy src/`, `pytest`
+- Tests use in-memory mocks, not live DB connections
+- Coverage target: maintain or improve current coverage
+- Use `pytest.mark.asyncio` for async test functions
+
+## What NOT to Do
+
+- Do not add pandas as a dependency
+- Do not use `type: ignore` — fix the type error or use TypedDict
+- Do not modify `db/init.sql` without considering migration impact
+- Do not commit directly to main

--- a/.github/copilot-setup-steps.yml
+++ b/.github/copilot-setup-steps.yml
@@ -1,0 +1,17 @@
+# Environment setup for GitHub Copilot Coding Agent
+# The agent runs these steps in a Codespace before making changes.
+# Docs: https://docs.github.com/en/copilot/using-github-copilot/using-the-copilot-coding-agent
+
+setup:
+  - name: Install uv
+    run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+  - name: Install Python dependencies
+    run: uv sync --frozen --all-extras
+
+  - name: Verify CI checks pass
+    run: |
+      uv run ruff check src/ tests/
+      uv run ruff format --check src/ tests/
+      uv run mypy src/
+      uv run pytest --tb=short -q


### PR DESCRIPTION
## Summary

Adds GitHub Copilot agent configuration files so the enabled agents work with our project conventions.

- **`copilot-setup-steps.yml`**: Defines environment setup for the Coding Agent — installs uv, syncs deps, runs full CI (ruff, mypy, pytest) before submitting changes
- **`copilot-instructions.md`**: Project context fed to all Copilot features (code review, chat, completions, coding agent) — stack, conventions, security rules, what not to do

## Agents Enabled

| Agent | Config | Purpose |
|-------|--------|---------|
| Coding Agent | `copilot-setup-steps.yml` | Assign issues → auto-generates PRs |
| Code Review | `copilot-instructions.md` | Automated PR review with project context |
| Autofix | GitHub Advanced Security | Auto-remediate vulnerability alerts |
| PR Summaries | UI toggle | Auto-generate PR descriptions |

## Test Plan

- [x] Files follow GitHub's expected schema
- [ ] Assign a test issue to `@copilot` to verify coding agent picks up setup steps
- [ ] Request review from `copilot` on this PR to verify instructions are loaded