### PR TITLE
fix(docs): align version references across documentation (#196)

### DIFF
--- a/.github/agents/bug-fixer.agent.md
+++ b/.github/agents/bug-fixer.agent.md
@@ -14,7 +14,7 @@ You are the Bug Fixer agent for the Argus CMS Fraud Detection project — a proa
 - **AI Layer**: AWS Bedrock Claude (`src/ai/`) — `text_to_sql.py` (NL→SQL), `narrative.py` (risk briefs), `bedrock.py` (client)
 - **Pipeline**: Polars feature engineering (`src/pipeline/build_features.py`)
 - **Data**: psycopg COPY bulk loader (`src/data/load_postgres.py`)
-- **Frontend**: Next.js 16 + Tailwind v4 + shadcn/ui (`frontend/`)
+- **Frontend**: Next.js 16.2.0 + Tailwind v4 + shadcn/ui (`frontend/`)
 - **DB**: PostgreSQL 16 (`provider_features` 63 cols, `provider_service_cases`) + Neo4j 5 (network risk)
 - **Tests**: 24 test files in `tests/`, all use mocks — no live DB connections
 

--- a/.github/agents/code-reviewer.agent.md
+++ b/.github/agents/code-reviewer.agent.md
@@ -17,7 +17,7 @@ Identifies anomalous Medicare billing patterns using peer comparison, determinis
 - **Scoring**: Deterministic rule engine (`src/scoring/`) — `taxonomy.py` (signals/weights), `score.py`, `extract.py`
 - **AI Layer**: AWS Bedrock Claude (`src/ai/`) — `text_to_sql.py` (NL→SQL with guardrails), `narrative.py` (risk briefs), `bedrock.py` (client)
 - **Pipeline**: Polars feature engineering (`src/pipeline/build_features.py`)
-- **Frontend**: Next.js 16 + Tailwind v4 + shadcn/ui + Recharts (`frontend/`)
+- **Frontend**: Next.js 16.2.0 + Tailwind v4 + shadcn/ui + Recharts (`frontend/`)
 - **DB**: PostgreSQL 16 (`provider_features` 63 cols, `provider_service_cases`) + Neo4j 5 (network risk)
 - **Tests**: pytest + pytest-asyncio in `tests/` — 24 test files, all mocked (no live DB)
 

--- a/.github/agents/docs-writer.agent.md
+++ b/.github/agents/docs-writer.agent.md
@@ -17,7 +17,7 @@ Identifies anomalous Medicare billing patterns using peer comparison, determinis
 - **Scoring**: Deterministic rule engine (`src/scoring/`) — 14 signals in `taxonomy.py`
 - **AI Layer**: AWS Bedrock Claude (`src/ai/`) — text-to-SQL (Haiku 4.5), risk narratives (Sonnet 4.6)
 - **Pipeline**: Polars feature engineering (`src/pipeline/build_features.py`)
-- **Frontend**: Next.js 16 + Tailwind v4 + shadcn/ui + Recharts (`frontend/`)
+- **Frontend**: Next.js 16.2.0 + Tailwind v4 + shadcn/ui + Recharts (`frontend/`)
 - **DB**: PostgreSQL 16 + Neo4j 5
 - **Infra**: EKS + ArgoCD + Terraform, deployed at `argus.precise-lab.com`
 

--- a/.github/agents/security-auditor.agent.md
+++ b/.github/agents/security-auditor.agent.md
@@ -25,7 +25,7 @@ Identifies anomalous Medicare billing patterns using peer comparison, determinis
   - `narrative.py` — risk narrative generation (output displayed to users)
 - **Scoring** (`src/scoring/`) — deterministic, no AI involvement in scoring logic
 - **DB**: PostgreSQL 16 (psycopg parameterized queries) + Neo4j 5 (bolt protocol)
-- **Frontend**: Next.js 16 (`frontend/`) — server components, API calls via `fetch`
+- **Frontend**: Next.js 16.2.0 (`frontend/`) — server components, API calls via `fetch`
 
 ### Known Security Decisions
 

--- a/.github/agents/senior-developer.agent.md
+++ b/.github/agents/senior-developer.agent.md
@@ -50,7 +50,7 @@ Implement features and enhancements from issue requirements. You write productio
 - **Validation**: Retrospective testing (`src/validation/`)
 - **Models**: ML models like Isolation Forest (`src/models/`)
 
-### Frontend (Next.js 16 + TypeScript)
+### Frontend (Next.js 16.2.0 + TypeScript)
 
 - Located in `frontend/`
 - Tailwind v4 + shadcn/ui + Recharts + react-force-graph-2d

--- a/.github/agents/technical-pm.agent.md
+++ b/.github/agents/technical-pm.agent.md
@@ -84,7 +84,7 @@ When asked to plan a sprint or batch of work:
 ### Architecture
 
 - **Backend**: FastAPI + psycopg + Polars (Python 3.12+)
-- **Frontend**: Next.js 16 + Tailwind v4 + shadcn/ui
+- **Frontend**: Next.js 16.2.0 + Tailwind v4 + shadcn/ui
 - **DB**: PostgreSQL 16 + Neo4j 5
 - **AI**: AWS Bedrock Claude (text-to-SQL, risk narratives)
 - **Infra**: EKS + ArgoCD + Terraform

--- a/.github/agents/test-engineer.agent.md
+++ b/.github/agents/test-engineer.agent.md
@@ -20,7 +20,7 @@ Identifies anomalous Medicare billing patterns using peer comparison, determinis
 - **Data**: psycopg COPY bulk loader (`src/data/load_postgres.py`)
 - **Models**: Isolation Forest anomaly detection (`src/models/anomaly.py`)
 - **Validation**: Retrospective testing (`src/validation/retrospective.py`)
-- **Frontend**: Next.js 16 (`frontend/`) — not tested by Python CI
+- **Frontend**: Next.js 16.2.0 (`frontend/`) — not tested by Python CI
 
 ### External Dependencies to Mock
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,7 +11,7 @@ Proactive CMS provider fraud detection with explainable AI. Identifies anomalous
 - **AI Layer**: AWS Bedrock Claude for text-to-SQL and risk narratives (`src/ai/`)
 - **DB**: PostgreSQL 16 (provider_features: 63 columns, provider_service_cases: case-level)
 - **Graph**: Neo4j 5 for network risk signals
-- **Frontend**: Next.js 16 + Tailwind v4 + shadcn/ui + Recharts
+- **Frontend**: Next.js 16.2.0 + Tailwind v4 + shadcn/ui + Recharts
 - **Python**: 3.12+, type-checked with mypy, linted with ruff
 
 ## Conventions

--- a/README.md
+++ b/README.md
@@ -62,15 +62,15 @@ CMS loses an estimated $60B+ annually to improper payments across Medicare and M
 
 **Live App**: [argus.precise-lab.com](https://argus.precise-lab.com) | **Validation Endpoint**: [/api/validation](/api/validation)
 
-| Deliverable | Document |
-|---|---|
-| Risk Scoring Methodology | [docs/risk-scoring-methodology.md](docs/risk-scoring-methodology.md) |
-| Responsible AI Considerations | [docs/responsible-ai-considerations.md](docs/responsible-ai-considerations.md) |
-| AI & Open Source Disclosure | [docs/ai-oss-disclosure.md](docs/ai-oss-disclosure.md) |
-| Path to CMS Pilot (5-min brief) | [docs/path-to-cms-pilot.md](docs/path-to-cms-pilot.md) |
-| Demo Script (5-7 min) | [docs/demo-script.md](docs/demo-script.md) |
-| Isolation Forest Model Card | [docs/model-card-isolation-forest.md](docs/model-card-isolation-forest.md) |
-| Architecture Diagrams | [docs/diagrams/](docs/diagrams/) |
+| Deliverable                     | Document                                                                       |
+| ------------------------------- | ------------------------------------------------------------------------------ |
+| Risk Scoring Methodology        | [docs/risk-scoring-methodology.md](docs/risk-scoring-methodology.md)           |
+| Responsible AI Considerations   | [docs/responsible-ai-considerations.md](docs/responsible-ai-considerations.md) |
+| AI & Open Source Disclosure     | [docs/ai-oss-disclosure.md](docs/ai-oss-disclosure.md)                         |
+| Path to CMS Pilot (5-min brief) | [docs/path-to-cms-pilot.md](docs/path-to-cms-pilot.md)                         |
+| Demo Script (5-7 min)           | [docs/demo-script.md](docs/demo-script.md)                                     |
+| Isolation Forest Model Card     | [docs/model-card-isolation-forest.md](docs/model-card-isolation-forest.md)     |
+| Architecture Diagrams           | [docs/diagrams/](docs/diagrams/)                                               |
 
 ## Key Principles
 
@@ -137,7 +137,7 @@ All datasets are publicly available and currently downloadable. No PHI is used.
 
 | Layer    | Technology                                           | Status |
 | -------- | ---------------------------------------------------- | ------ |
-| Frontend | Next.js 16 + TypeScript + Tailwind + shadcn/ui       | Live   |
+| Frontend | Next.js 16.2.0 + TypeScript + Tailwind + shadcn/ui   | Live   |
 | Backend  | Python 3.12 + FastAPI + psycopg                      | Live   |
 | Database | PostgreSQL 16 (EKS StatefulSet)                      | Live   |
 | Graph    | Neo4j 5 Community (EKS StatefulSet)                  | Live   |

--- a/docs/architecture-v3.md
+++ b/docs/architecture-v3.md
@@ -262,20 +262,20 @@ and disparate impact measures.
 
 ## Tech Stack
 
-| Layer         | Technology               | Why                                                    |
-| ------------- | ------------------------ | ------------------------------------------------------ |
-| Frontend      | Next.js 16 + TypeScript  | SSR, app router, API routes as BFF                     |
-| UI Components | shadcn/ui + Tailwind CSS | Polished, accessible, fast to build                    |
-| Charts        | Recharts                 | React-native, composable, AI can specify chart configs |
-| Backend       | Python 3.12 + FastAPI    | Async, auto-docs, scoring engine                       |
-| Database      | PostgreSQL 16            | Operational store, SQL queries, production-grade       |
-| Graph         | Neo4j 5                  | Relationship traversal, Cypher queries                 |
-| ETL           | DuckDB + Polars          | One-time data processing (not runtime)                 |
-| AI            | AWS Bedrock (Claude)     | FedRAMP authorized, GovCloud-ready, multi-model        |
-| Containers    | Docker + docker-compose  | Local dev, multi-service                               |
-| CI            | GitHub Actions           | Lint, test, build, coverage                            |
-| CD            | ArgoCD                   | GitOps deployment to EKS                               |
-| Registry      | Amazon ECR               | AWS-native container image store                       |
+| Layer         | Technology                  | Why                                                    |
+| ------------- | --------------------------- | ------------------------------------------------------ |
+| Frontend      | Next.js 16.2.0 + TypeScript | SSR, app router, API routes as BFF                     |
+| UI Components | shadcn/ui + Tailwind CSS    | Polished, accessible, fast to build                    |
+| Charts        | Recharts                    | React-native, composable, AI can specify chart configs |
+| Backend       | Python 3.12 + FastAPI       | Async, auto-docs, scoring engine                       |
+| Database      | PostgreSQL 16               | Operational store, SQL queries, production-grade       |
+| Graph         | Neo4j 5                     | Relationship traversal, Cypher queries                 |
+| ETL           | DuckDB + Polars             | One-time data processing (not runtime)                 |
+| AI            | AWS Bedrock (Claude)        | FedRAMP authorized, GovCloud-ready, multi-model        |
+| Containers    | Docker + docker-compose     | Local dev, multi-service                               |
+| CI            | GitHub Actions              | Lint, test, build, coverage                            |
+| CD            | ArgoCD                      | GitOps deployment to EKS                               |
+| Registry      | Amazon ECR                  | AWS-native container image store                       |
 
 ## Data Flow
 
@@ -519,7 +519,7 @@ cms-fraud-detection/
 │   ├── Dockerfile
 │   └── alembic/                # DB migrations
 │       └── versions/
-├── frontend/                   # Next.js 16 application
+├── frontend/                   # Next.js 16.2.0 application
 │   ├── app/
 │   │   ├── layout.tsx          # Root layout + nav + search bar
 │   │   ├── page.tsx            # Overview dashboard (landing page)
@@ -868,7 +868,7 @@ responsible AI. Provider search available from every view.
 
 **Stories**:
 
-1. Scaffold Next.js 16 + TypeScript + shadcn/ui project
+1. Scaffold Next.js 16.2.0 + TypeScript + shadcn/ui project
 2. Build overview dashboard page (stat cards, top flagged list)
 3. Build risk heatmap component (US choropleth map)
 4. Build provider search with autocomplete


### PR DESCRIPTION
## Summary

- Standardizes Next.js version to **16.2.0** (from `frontend/package.json`) across all docs and agent instruction files
- All 10 occurrences of "Next.js 16" updated to "Next.js 16.2.0"
- Python 3.12, PostgreSQL 16, and Neo4j 5 Community were already consistent — no changes needed there

## Files changed

- `README.md` — tech stack table
- `docs/architecture-v3.md` — tech stack table, directory tree comment, frontend phase story
- `.github/copilot-instructions.md` — stack section
- `.github/agents/bug-fixer.agent.md`
- `.github/agents/code-reviewer.agent.md`
- `.github/agents/docs-writer.agent.md`
- `.github/agents/security-auditor.agent.md`
- `.github/agents/senior-developer.agent.md`
- `.github/agents/technical-pm.agent.md`
- `.github/agents/test-engineer.agent.md`

## Test plan

- [x] `ruff check src/ tests/` — passed
- [x] `ruff format --check src/ tests/` — passed
- [x] `mypy src/` — passed
- [x] `pytest --tb=short -q` — 347 passed, 0 failed

Closes #196