### PR TITLE
fix(docs): correct signal taxonomy diagram to match implementation (#184)

### DIFF
--- a/docs/diagrams/08-signal-taxonomy.mmd
+++ b/docs/diagrams/08-signal-taxonomy.mmd
@@ -1,31 +1,32 @@
 %%{init: {'theme': 'base', 'themeVariables': {'primaryColor': '#e2e8f0', 'primaryTextColor': '#1e293b', 'primaryBorderColor': '#94a3b8', 'lineColor': '#64748b', 'secondaryColor': '#f1f5f9', 'tertiaryColor': '#f8fafc', 'fontFamily': 'Inter, system-ui, sans-serif'}}}%%
 
 graph TB
-    ROOT["Signal Taxonomy<br/><b>CMS Provider Intelligence</b>"]
+    ROOT["Signal Taxonomy<br/><b>13 Explainable Signals</b>"]
 
-    subgraph RISK["RISK SIGNALS — Increase Suspicion"]
+    subgraph RISK["RISK SIGNALS — 6 Signals"]
         direction TB
-        R1["Volume Outlier<br/><i>tot_srvcs z-score > 2.0</i><br/>Source: Part B Provider-Service<br/>Points: +15 to +25"]
-        R2["Charge Anomaly<br/><i>submitted/allowed ratio z > 2.0</i><br/>Source: Part B Provider-Service<br/>Points: +10 to +20"]
-        R3["Service Intensity<br/><i>services_per_bene z > 2.0</i><br/>Source: Part B Provider-Service<br/>Points: +10 to +20"]
-        R4["Payment Outlier<br/><i>avg_payment z > 2.0</i><br/>Source: Part B Provider-Service<br/>Points: +10 to +15"]
-        R5["Enrollment Gap<br/><i>Not in enrollment file</i><br/>Source: Enrollment<br/>Points: +15"]
-        R6["Revocation Flag<br/><i>OIG exclusion match</i><br/>Source: OIG LEIE<br/>Points: +25"]
-        R7["Abnormal Growth<br/><i>YoY volume spike > 50%</i><br/>Source: Part B multi-year<br/>Points: +10 to +15"]
+        R1["revoked_provider<br/><i>Provider in 2026 revocation file</i><br/>Category: enrollment<br/><b>+25 points</b>"]
+        R2["not_in_current_enrollment_file<br/><i>Not in current 2025 enrollment</i><br/>Category: enrollment<br/><b>+8 points</b>"]
+        R3["service_volume_outlier<br/><i>Total services z-score vs peers</i><br/>Category: peer<br/><b>z≥5: +20 | z≥3: +14 | z≥2: +8</b>"]
+        R4["service_intensity_outlier<br/><i>Services per bene z-score vs peers</i><br/>Category: peer<br/><b>z≥5: +18 | z≥3: +12 | z≥2: +7</b>"]
+        R5["charge_ratio_outlier<br/><i>Submitted/allowed ratio z-score</i><br/>Category: peer<br/><b>z≥5: +18 | z≥3: +12 | z≥2: +7</b>"]
+        R6["payment_outlier<br/><i>Avg payment z-score vs peers</i><br/>Category: peer<br/><b>z≥5: +12 | z≥3: +8 | z≥2: +5</b>"]
     end
 
-    subgraph LEGIT["LEGITIMACY SIGNALS — Stabilize Score"]
+    subgraph LEGIT["LEGITIMACY SIGNALS — 7 Signals"]
         direction TB
-        L1["Medicare Participating<br/><i>Accepts assignment</i><br/>Source: Part B Provider<br/>Points: -10"]
-        L2["Low Volume<br/><i>Below 2σ threshold</i><br/>Source: Part B Provider-Service<br/>Points: -5 to -10"]
-        L3["Clean Record<br/><i>No revocations found</i><br/>Source: OIG LEIE<br/>Points: -5"]
-        L4["Active Enrollment<br/><i>Present in enrollment</i><br/>Source: Enrollment<br/>Points: -5"]
-        L5["Consistent Billing<br/><i>Low variance vs peers</i><br/>Source: Part B Provider-Service<br/>Points: -5"]
+        L1["present_in_current_enrollment_file<br/><i>Found in 2025 enrollment</i><br/>Category: enrollment<br/><b>+20 points</b>"]
+        L2["no_revocation_match<br/><i>No revocation on record</i><br/>Category: enrollment<br/><b>+15 points</b>"]
+        L3["medicare_participating<br/><i>Accepts Medicare assignment</i><br/>Category: enrollment<br/><b>+10 points</b>"]
+        L4["peer_aligned_volume<br/><i>Service volume |z| &lt; 1.0</i><br/>Category: peer<br/><b>+12 points</b>"]
+        L5["peer_aligned_intensity<br/><i>Services per bene |z| &lt; 1.0</i><br/>Category: peer<br/><b>+12 points</b>"]
+        L6["peer_aligned_pricing<br/><i>Charge ratio |z| &lt; 1.0</i><br/>Category: peer<br/><b>+12 points</b>"]
+        L7["large_patient_panel<br/><i>Serves 100+ Medicare benes</i><br/>Category: volume<br/><b>+8 points</b>"]
     end
 
     subgraph SCORING["SCORE COMPUTATION"]
-        FORMULA["Risk Score = Σ risk_points<br/>Legitimacy Score = Σ legit_points<br/>Both clamped to 0-100"]
-        LABELS["high_risk: risk ≥ 70<br/>review: risk 40-69<br/>stable: risk < 40"]
+        FORMULA["Risk Score = Σ risk signal points<br/>Legitimacy Score = Σ legitimacy signal points<br/>Both capped at 100"]
+        LABELS["<b>high_risk</b>: risk ≥ 51 AND risk ≥ legitimacy + 5<br/><b>stable</b>: legitimacy ≥ 70 AND risk &lt; 30<br/><b>review</b>: everything else"]
     end
 
     ROOT --> RISK


### PR DESCRIPTION
Closes #184

## Changes
Rewrote `docs/diagrams/08-signal-taxonomy.mmd` to match the actual implementation in `src/scoring/taxonomy.py`:

| Before (wrong) | After (correct) |
|---|---|
| 7 risk signals | 6 risk signals |
| 5 legitimacy signals | 7 legitimacy signals |
| Included "Abnormal Growth" (doesn't exist) | Removed |
| Legitimacy used negative points (-10, -5) | Positive points (+20, +15, etc.) |
| `high_risk: >= 70` | `high_risk: >= 51 AND risk >= legitimacy + 5` |
| Missing z-score tiers | All tiers shown (z≥5, z≥3, z≥2) |

## Test
- Docs-only change, no code impact