### PR TITLE
feat(scoring): add concentration_outlier signal — 14th signal (#183)

### DIFF
--- a/src/scoring/extract.py
+++ b/src/scoring/extract.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 
 from src.scoring.taxonomy import (
     CHARGE_RATIO_OUTLIER,
+    CONCENTRATION_OUTLIER,
     ENROLLED_CURRENT,
     LARGE_PATIENT_PANEL,
     MEDICARE_PARTICIPATING,
@@ -67,6 +68,7 @@ def extract_signals(case: dict) -> list[FiredSignal]:
     _extract_peer_risk(case, signals)
     _extract_peer_legitimacy(case, signals)
     _extract_large_panel(case, signals)
+    _extract_concentration(case, signals)
 
     return signals
 
@@ -179,5 +181,39 @@ def _extract_large_panel(case: dict, out: list[FiredSignal]) -> None:
                 points=LARGE_PATIENT_PANEL.points,  # type: ignore[arg-type]
                 value=float(benes),
                 reason=LARGE_PATIENT_PANEL.description,
+            )
+        )
+
+
+def _extract_concentration(case: dict, out: list[FiredSignal]) -> None:
+    top_share = case.get("top_code_share")
+    hhi = case.get("service_hhi")
+
+    # Tiered: top_code_share >= 0.90 → 12pts, >= 0.80 → 8pts, hhi >= 0.50 → 6pts
+    if top_share is not None and top_share >= 0.90:
+        out.append(
+            FiredSignal(
+                signal=CONCENTRATION_OUTLIER,
+                points=12,
+                value=round(float(top_share), 3),
+                reason=f"Provider derives {top_share * 100:.0f}% of billing from one code",
+            )
+        )
+    elif top_share is not None and top_share >= 0.80:
+        out.append(
+            FiredSignal(
+                signal=CONCENTRATION_OUTLIER,
+                points=8,
+                value=round(float(top_share), 3),
+                reason=f"Provider derives {top_share * 100:.0f}% of billing from one code",
+            )
+        )
+    elif hhi is not None and hhi >= 0.50:
+        out.append(
+            FiredSignal(
+                signal=CONCENTRATION_OUTLIER,
+                points=6,
+                value=round(float(hhi), 3),
+                reason=f"Billing concentration index (HHI={hhi:.2f}) indicates narrow service mix",
             )
         )

--- a/src/scoring/taxonomy.py
+++ b/src/scoring/taxonomy.py
@@ -149,6 +149,15 @@ PAYMENT_OUTLIER = SignalDef(
     requires_peers=True,
 )
 
+CONCENTRATION_OUTLIER = SignalDef(
+    name="concentration_outlier",
+    category=SignalCategory.charge,
+    direction=SignalDirection.risk,
+    description="Billing concentrated in a single service code",
+    points=12,  # max tier; extract.py applies tiered logic
+    threshold=0.80,
+)
+
 RISK_SIGNALS: tuple[SignalDef, ...] = (
     REVOKED_PROVIDER,
     NOT_IN_ENROLLMENT,
@@ -156,6 +165,7 @@ RISK_SIGNALS: tuple[SignalDef, ...] = (
     SERVICE_INTENSITY_OUTLIER,
     CHARGE_RATIO_OUTLIER,
     PAYMENT_OUTLIER,
+    CONCENTRATION_OUTLIER,
 )
 
 # ---------------------------------------------------------------------------

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from src.scoring.extract import FiredSignal, extract_signals
 from src.scoring.taxonomy import (
     CHARGE_RATIO_OUTLIER,
+    CONCENTRATION_OUTLIER,
     ENROLLED_CURRENT,
     LARGE_PATIENT_PANEL,
     MEDICARE_PARTICIPATING,
@@ -286,6 +287,51 @@ class TestLargePatientPanel:
         s = _find(signals, LARGE_PATIENT_PANEL.name)
         assert s is not None
         assert s.value == 250.0
+
+
+# ---------------------------------------------------------------------------
+# Concentration outlier
+# ---------------------------------------------------------------------------
+
+
+class TestConcentrationOutlier:
+    def test_extreme_top_code_share(self):
+        signals = extract_signals(_base_case(top_code_share=0.95))
+        s = _find(signals, CONCENTRATION_OUTLIER.name)
+        assert s is not None
+        assert s.points == 12
+
+    def test_high_top_code_share(self):
+        signals = extract_signals(_base_case(top_code_share=0.85))
+        s = _find(signals, CONCENTRATION_OUTLIER.name)
+        assert s is not None
+        assert s.points == 8
+
+    def test_hhi_fires_when_top_code_below_threshold(self):
+        signals = extract_signals(_base_case(top_code_share=0.5, service_hhi=0.55))
+        s = _find(signals, CONCENTRATION_OUTLIER.name)
+        assert s is not None
+        assert s.points == 6
+
+    def test_top_code_takes_priority_over_hhi(self):
+        signals = extract_signals(_base_case(top_code_share=0.92, service_hhi=0.6))
+        s = _find(signals, CONCENTRATION_OUTLIER.name)
+        assert s is not None
+        assert s.points == 12  # top_code tier, not HHI
+
+    def test_does_not_fire_below_thresholds(self):
+        signals = extract_signals(_base_case(top_code_share=0.5, service_hhi=0.3))
+        assert CONCENTRATION_OUTLIER.name not in _signal_names(signals)
+
+    def test_does_not_fire_when_missing(self):
+        signals = extract_signals(_base_case())
+        assert CONCENTRATION_OUTLIER.name not in _signal_names(signals)
+
+    def test_reason_includes_percentage(self):
+        signals = extract_signals(_base_case(top_code_share=0.91))
+        s = _find(signals, CONCENTRATION_OUTLIER.name)
+        assert s is not None
+        assert "91%" in s.reason
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -22,7 +22,7 @@ from src.scoring.taxonomy import (
 
 class TestSignalDefinitions:
     def test_risk_signal_count(self):
-        assert len(RISK_SIGNALS) == 6
+        assert len(RISK_SIGNALS) == 7
 
     def test_legitimacy_signal_count(self):
         assert len(LEGITIMACY_SIGNALS) == 7


### PR DESCRIPTION
## Summary
- Add `concentration_outlier` risk signal to taxonomy with tiered thresholds
  - `top_code_share >= 0.90` → 12 pts (extreme concentration)
  - `top_code_share >= 0.80` → 8 pts (high concentration)
  - `service_hhi >= 0.50` → 6 pts (moderate, only if top_code didn't fire)
- Wire extraction logic in `extract.py` with `elif` priority chain
- Update risk signal count: 6 → 7 (total 14 signals: 7 risk + 7 legitimacy)
- Add 7 unit tests covering all tiers, priority, edge cases, and reason strings

## Test plan
- [x] ruff lint + format: clean
- [x] mypy: 0 errors
- [x] pytest: 366 passed (7 new)

Closes #183