### PR TITLE
feat(chat): add LLM synthesis for multi-row query results (#189)

### DIFF
--- a/src/ai/text_to_sql.py
+++ b/src/ai/text_to_sql.py
@@ -144,6 +144,12 @@ async def text_to_sql(
     # Build a text answer from the results
     answer = _format_answer(question, columns, rows)
 
+    # For multi-row results, synthesize an insight summary via LLM
+    if len(rows) > 1:
+        synthesis = await _synthesize_results(question, columns, rows)
+        if synthesis:
+            answer = synthesis
+
     logger.info(
         "text_to_sql question=%r rows=%d duration=%dms sql=%s",
         question[:80],
@@ -191,3 +197,46 @@ def _format_value(val: Any) -> str:
             return f"{val:,.0f}"
         return f"{val:.2f}"
     return str(val)
+
+
+_SYNTHESIS_PROMPT = (
+    "You are a CMS fraud analyst assistant. "
+    "Summarize these query results in 2-3 sentences. "
+    "Highlight the most notable patterns. Be specific with numbers. "
+    "Do not use markdown formatting."
+)
+
+
+async def _synthesize_results(
+    question: str,
+    columns: list[str],
+    rows: list[dict[str, Any]],
+) -> str | None:
+    """Generate an LLM summary for multi-row query results.
+
+    Returns a 2-3 sentence synthesis, or None on failure (non-fatal).
+    """
+    # Serialize top rows as a compact table for the LLM
+    display_rows = rows[:10]
+    header = " | ".join(columns)
+    lines = [header]
+    for row in display_rows:
+        lines.append(" | ".join(str(row.get(c, "")) for c in columns))
+    if len(rows) > 10:
+        lines.append(f"... ({len(rows)} total rows)")
+    table = "\n".join(lines)
+
+    user_msg = f"Question: {question}\n\nResults:\n{table}"
+
+    try:
+        response = await invoke(
+            messages=[{"role": "user", "content": user_msg}],
+            system=_SYNTHESIS_PROMPT,
+            model=CHAT_MODEL,
+            max_tokens=150,
+            temperature=0.2,
+        )
+        return str(response["text"]).strip()
+    except Exception:
+        logger.exception("Result synthesis failed, falling back to count")
+        return None

--- a/tests/test_text_to_sql.py
+++ b/tests/test_text_to_sql.py
@@ -2,9 +2,17 @@
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, patch
+
 import pytest
 
-from src.ai.text_to_sql import SQLValidationError, _format_answer, _format_value, validate_sql
+from src.ai.text_to_sql import (
+    SQLValidationError,
+    _format_answer,
+    _format_value,
+    _synthesize_results,
+    validate_sql,
+)
 
 # ---------------------------------------------------------------------------
 # SQL validation tests
@@ -269,3 +277,58 @@ def test_format_answer_multiple_rows():
     rows = [{"id": 1}, {"id": 2}, {"id": 3}]
     result = _format_answer("q", ["id"], rows)
     assert "3 results" in result
+
+
+# ---------------------------------------------------------------------------
+# Synthesis tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_synthesize_results_returns_summary():
+    mock_resp = {"text": "Internal Medicine leads with 23% flagging rate."}
+    with patch(
+        "src.ai.text_to_sql.invoke",
+        new_callable=AsyncMock,
+        return_value=mock_resp,
+    ):
+        result = await _synthesize_results(
+            "Which specialties have the most outliers?",
+            ["specialty", "count"],
+            [
+                {"specialty": "Internal Medicine", "count": 42},
+                {"specialty": "Cardiology", "count": 31},
+            ],
+        )
+    assert result is not None
+    assert "Internal Medicine" in result
+
+
+@pytest.mark.asyncio
+async def test_synthesize_results_fallback_on_error():
+    with patch(
+        "src.ai.text_to_sql.invoke",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("boom"),
+    ):
+        result = await _synthesize_results(
+            "test question",
+            ["col"],
+            [{"col": 1}, {"col": 2}],
+        )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_synthesize_limits_to_10_rows():
+    rows = [{"id": i} for i in range(20)]
+    mock_resp = {"text": "Summary of 20 rows."}
+    with patch(
+        "src.ai.text_to_sql.invoke",
+        new_callable=AsyncMock,
+        return_value=mock_resp,
+    ) as mock:
+        await _synthesize_results("q", ["id"], rows)
+        call_args = mock.call_args
+        user_msg = call_args.kwargs["messages"][0]["content"]
+        assert "20 total rows" in user_msg


### PR DESCRIPTION
## Summary
- Add `_synthesize_results()` async function that sends top 10 rows to Claude Haiku with a concise system prompt for 2-3 sentence data summaries
- Wire into `text_to_sql()` for multi-row results (>1 row), replacing generic "Found N results." with insight-rich answers
- Falls back gracefully to count-based answer on LLM failure (non-fatal)
- Single-row and scalar results remain unchanged — no latency impact

**Before**: "Found 15 results."  
**After**: "Internal Medicine has the highest outlier rate at 23% of providers flagged, followed by Cardiology (19%). Florida and Texas account for 45% of all high-risk providers."

## Test plan
- [x] ruff lint + format: clean
- [x] mypy: 0 errors
- [x] pytest: 362 passed (3 new async tests)

Closes #189