### PR TITLE
fix(api): document peer z-score proxy strategy (#188)

### DIFF
--- a/src/api/routes/score.py
+++ b/src/api/routes/score.py
@@ -113,11 +113,13 @@ async def score_claim(
             case["service_volume_peer_z"] = _z_score(
                 req.tot_srvcs, peers["avg_srvcs"], peers["std_srvcs"]
             )
-            case["services_per_bene_peer_z"] = None  # no bene count in ScoreRequest
-            # Use submitted charge as proxy for charge ratio z-score
+            # ScoreRequest has no num_benes — cannot compute per-bene intensity
+            case["services_per_bene_peer_z"] = None
+            # ScoreRequest has no avg_medicare_allowed_amt — use submitted charge as proxy
             case["submitted_to_allowed_peer_z"] = _z_score(
                 req.avg_submitted_charge, peers["avg_ratio"], peers["std_ratio"]
             )
+            # ScoreRequest has no avg_medicare_payment_amt — use submitted charge as proxy
             case["payment_peer_z"] = _z_score(
                 req.avg_submitted_charge, peers["avg_payment"], peers["std_payment"]
             )

--- a/src/api/routes/simulate.py
+++ b/src/api/routes/simulate.py
@@ -163,10 +163,11 @@ async def simulate_claim(
         case["services_per_bene_peer_z"] = _z_score(
             services_per_bene, peers["avg_spb"], peers["std_spb"]
         )
-        # Use submitted charge as proxy for charge ratio and payment z-scores
+        # No avg_medicare_allowed_amt in request — use submitted charge as proxy
         case["submitted_to_allowed_peer_z"] = _z_score(
             req.submitted_charge, peers["avg_ratio"], peers["std_ratio"]
         )
+        # No avg_medicare_payment_amt (only known post-adjudication) — use submitted charge
         case["payment_peer_z"] = _z_score(
             req.submitted_charge, peers["avg_payment"], peers["std_payment"]
         )


### PR DESCRIPTION
## Summary
- Replace terse z-score comments with precise explanations of *why* each is None or uses a proxy
- `score.py`: `services_per_bene_peer_z` → None (ScoreRequest has no `num_benes`), charge/payment z-scores use `avg_submitted_charge` as proxy
- `simulate.py`: charge ratio and payment z-scores use `submitted_charge` as proxy (allowed/payment amounts unknown pre-adjudication)
- Comment-only change — no behavioral differences

## Test plan
- [x] pytest: 359 passed (no behavioral changes)

Closes #188