### PR TITLE
fix(deploy): resolve chat SET timeout bug and add missing data dirs (#234)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ WORKDIR /app
 COPY --from=builder /install /usr/local
 COPY --from=builder /app/src src/
 COPY pyproject.toml .
+COPY data/validation/ data/validation/
+COPY data/models/ data/models/
 
 USER appuser
 

--- a/src/ai/text_to_sql.py
+++ b/src/ai/text_to_sql.py
@@ -131,7 +131,7 @@ async def text_to_sql(
     # Execute with timeout
     start = time.monotonic()
     async with conn.cursor() as cur:
-        await cur.execute("SET statement_timeout = %s", [str(QUERY_TIMEOUT_MS)])
+        await cur.execute(f"SET statement_timeout = {int(QUERY_TIMEOUT_MS)}")
         await cur.execute(sql)
         columns = [desc.name for desc in cur.description] if cur.description else []
         raw_rows = await cur.fetchall()


### PR DESCRIPTION
## Summary
Three bugs found during post-deploy EKS verification:

1. **Chat 500** — `SET statement_timeout = %s` fails because psycopg3 translates `%s` to `$1`, but PostgreSQL's `SET` doesn't accept parameterized values. Fixed with f-string using `int()` cast (safe: constant, not user input).

2. **Validation 500** — `data/validation/retrospective_results.json` referenced at runtime but never COPY'd into the Docker image.

3. **Anomaly scorer silent failure** — `data/models/isolation_forest.joblib` also missing from image.

## Changes
- `src/ai/text_to_sql.py`: Replace parameterized SET with f-string literal
- `Dockerfile`: Add `COPY data/validation/` and `COPY data/models/`

## Test plan
- [x] `ruff check` + `ruff format --check` clean
- [x] `mypy` — 0 errors
- [x] `pytest` — 389 passed
- [ ] After merge + deploy: verify `/api/chat` and `/api/validation` return 200

Closes #234