### PR TITLE
fix(frontend): remove nav double-highlight on Inbox/Providers

### DIFF
--- a/frontend/src/components/nav-sidebar.tsx
+++ b/frontend/src/components/nav-sidebar.tsx
@@ -22,7 +22,7 @@ const navItems = [
   { href: "/", label: "Dashboard", icon: LayoutDashboard },
   { href: "/investigate", label: "Inbox", icon: ClipboardList, badge: true },
   { href: "/simulate", label: "Simulate", icon: FlaskConical },
-  { href: "/providers", label: "Providers", icon: Search, altPrefixes: ["/investigate"] },
+  { href: "/providers", label: "Providers", icon: Search },
   { href: "/claims", label: "Claims", icon: FileText },
   { href: "/heatmap", label: "Risk Map", icon: Map },
   { href: "/fairness", label: "Fairness", icon: Shield },
@@ -81,9 +81,7 @@ export function NavSidebar({ onChatToggle, chatOpen }: NavSidebarProps) {
           const isActive =
             item.href === "/"
               ? pathname === "/"
-              : pathname.startsWith(item.href) ||
-                (item.altPrefixes?.some((p) => pathname.startsWith(p)) ??
-                  false);
+              : pathname.startsWith(item.href);
           return (
             <Link
               key={item.href}


### PR DESCRIPTION
## Summary
Providers nav item had `altPrefixes: ["/investigate"]`, causing both Inbox and Providers to highlight when on `/investigate/*` pages. Removed the altPrefix — Inbox already correctly matches via `pathname.startsWith("/investigate")`.

## Test plan
- [x] Navigate to `/investigate` — only Inbox highlights
- [x] Navigate to `/providers` — only Providers highlights

Closes #244