### PR TITLE
feat(frontend): add login page, auth context, and protected routes (#289)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,41 +1,76 @@
-import { lazy } from 'react';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import { Layout } from './components/Layout';
+import { lazy } from "react";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { AuthProvider } from "./contexts/AuthContext";
+import { ProtectedRoute } from "./components/ProtectedRoute";
+import { Layout } from "./components/Layout";
+import { Login } from "./pages/Login";
 
-const Dashboard = lazy(() => import('./pages/Dashboard').then((m) => ({ default: m.Dashboard })));
-const Simulate = lazy(() => import('./pages/Simulate').then((m) => ({ default: m.Simulate })));
-const Providers = lazy(() => import('./pages/Providers').then((m) => ({ default: m.Providers })));
-const ProviderDetail = lazy(() => import('./pages/ProviderDetail').then((m) => ({ default: m.ProviderDetail })));
-const Claims = lazy(() => import('./pages/Claims').then((m) => ({ default: m.Claims })));
-const ClaimDetail = lazy(() => import('./pages/ClaimDetail').then((m) => ({ default: m.ClaimDetail })));
-const Investigations = lazy(() => import('./pages/Investigations').then((m) => ({ default: m.Investigations })));
-const InvestigationDetail = lazy(() =>
-  import('./pages/InvestigationDetail').then((m) => ({ default: m.InvestigationDetail })),
+const Dashboard = lazy(() =>
+  import("./pages/Dashboard").then((m) => ({ default: m.Dashboard })),
 );
-const RiskMap = lazy(() => import('./pages/RiskMap').then((m) => ({ default: m.RiskMap })));
-const Fairness = lazy(() => import('./pages/Fairness').then((m) => ({ default: m.Fairness })));
-const Analytics = lazy(() => import('./pages/Analytics').then((m) => ({ default: m.Analytics })));
-const Validation = lazy(() => import('./pages/Validation').then((m) => ({ default: m.Validation })));
+const Simulate = lazy(() =>
+  import("./pages/Simulate").then((m) => ({ default: m.Simulate })),
+);
+const Providers = lazy(() =>
+  import("./pages/Providers").then((m) => ({ default: m.Providers })),
+);
+const ProviderDetail = lazy(() =>
+  import("./pages/ProviderDetail").then((m) => ({ default: m.ProviderDetail })),
+);
+const Claims = lazy(() =>
+  import("./pages/Claims").then((m) => ({ default: m.Claims })),
+);
+const ClaimDetail = lazy(() =>
+  import("./pages/ClaimDetail").then((m) => ({ default: m.ClaimDetail })),
+);
+const Investigations = lazy(() =>
+  import("./pages/Investigations").then((m) => ({ default: m.Investigations })),
+);
+const InvestigationDetail = lazy(() =>
+  import("./pages/InvestigationDetail").then((m) => ({
+    default: m.InvestigationDetail,
+  })),
+);
+const RiskMap = lazy(() =>
+  import("./pages/RiskMap").then((m) => ({ default: m.RiskMap })),
+);
+const Fairness = lazy(() =>
+  import("./pages/Fairness").then((m) => ({ default: m.Fairness })),
+);
+const Analytics = lazy(() =>
+  import("./pages/Analytics").then((m) => ({ default: m.Analytics })),
+);
+const Validation = lazy(() =>
+  import("./pages/Validation").then((m) => ({ default: m.Validation })),
+);
 
 export default function App() {
   return (
     <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<Layout />}>
-          <Route index element={<Dashboard />} />
-          <Route path="simulate" element={<Simulate />} />
-          <Route path="providers" element={<Providers />} />
-          <Route path="providers/:npi" element={<ProviderDetail />} />
-          <Route path="claims" element={<Claims />} />
-          <Route path="claims/:caseId" element={<ClaimDetail />} />
-          <Route path="investigations" element={<Investigations />} />
-          <Route path="investigations/:caseId" element={<InvestigationDetail />} />
-          <Route path="risk-map" element={<RiskMap />} />
-          <Route path="fairness" element={<Fairness />} />
-          <Route path="analytics" element={<Analytics />} />
-          <Route path="validation" element={<Validation />} />
-        </Route>
-      </Routes>
+      <AuthProvider>
+        <Routes>
+          <Route path="/login" element={<Login />} />
+          <Route element={<ProtectedRoute />}>
+            <Route path="/" element={<Layout />}>
+              <Route index element={<Dashboard />} />
+              <Route path="simulate" element={<Simulate />} />
+              <Route path="providers" element={<Providers />} />
+              <Route path="providers/:npi" element={<ProviderDetail />} />
+              <Route path="claims" element={<Claims />} />
+              <Route path="claims/:caseId" element={<ClaimDetail />} />
+              <Route path="investigations" element={<Investigations />} />
+              <Route
+                path="investigations/:caseId"
+                element={<InvestigationDetail />}
+              />
+              <Route path="risk-map" element={<RiskMap />} />
+              <Route path="fairness" element={<Fairness />} />
+              <Route path="analytics" element={<Analytics />} />
+              <Route path="validation" element={<Validation />} />
+            </Route>
+          </Route>
+        </Routes>
+      </AuthProvider>
     </BrowserRouter>
   );
 }

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,5 +1,5 @@
-import React, { Suspense } from 'react';
-import { NavLink, Outlet } from 'react-router-dom';
+import React, { Suspense } from "react";
+import { NavLink, Outlet } from "react-router-dom";
 import {
   LayoutDashboard,
   PlayCircle,
@@ -13,22 +13,25 @@ import {
   Menu,
   X,
   CheckCircle2,
-} from 'lucide-react';
-import { cn } from '../lib/utils';
+  LogOut,
+} from "lucide-react";
+import { cn } from "../lib/utils";
+import { useAuth } from "../contexts/AuthContext";
 
 const navigation = [
-  { name: 'Dashboard', href: '/', icon: LayoutDashboard },
-  { name: 'Simulate', href: '/simulate', icon: PlayCircle },
-  { name: 'Providers', href: '/providers', icon: Users },
-  { name: 'Claims', href: '/claims', icon: FileText },
-  { name: 'Investigations', href: '/investigations', icon: BriefcaseBusiness },
-  { name: 'Risk Map', href: '/risk-map', icon: MapIcon },
-  { name: 'Fairness', href: '/fairness', icon: ShieldCheck },
-  { name: 'Analytics', href: '/analytics', icon: Database },
-  { name: 'Validation', href: '/validation', icon: CheckCircle2 },
+  { name: "Dashboard", href: "/", icon: LayoutDashboard },
+  { name: "Simulate", href: "/simulate", icon: PlayCircle },
+  { name: "Providers", href: "/providers", icon: Users },
+  { name: "Claims", href: "/claims", icon: FileText },
+  { name: "Investigations", href: "/investigations", icon: BriefcaseBusiness },
+  { name: "Risk Map", href: "/risk-map", icon: MapIcon },
+  { name: "Fairness", href: "/fairness", icon: ShieldCheck },
+  { name: "Analytics", href: "/analytics", icon: Database },
+  { name: "Validation", href: "/validation", icon: CheckCircle2 },
 ];
 
 export function Layout() {
+  const { user, logout } = useAuth();
   const [isMobileMenuOpen, setIsMobileMenuOpen] = React.useState(false);
 
   return (
@@ -37,7 +40,9 @@ export function Layout() {
       <header className="h-14 bg-white border-b border-slate-200 flex items-center justify-between px-4 sticky top-0 z-50 shadow-sm">
         <div className="flex items-center gap-4">
           <div className="flex items-center gap-2">
-            <div className="w-8 h-8 bg-indigo-600 rounded flex items-center justify-center text-white font-bold text-lg">A</div>
+            <div className="w-8 h-8 bg-indigo-600 rounded flex items-center justify-center text-white font-bold text-lg">
+              A
+            </div>
             <span className="font-semibold text-lg tracking-tight text-slate-800">
               Argus <span className="text-indigo-600 font-bold">V2</span>
             </span>
@@ -54,8 +59,32 @@ export function Layout() {
         </div>
 
         <div className="flex items-center gap-3">
-          <button className="md:hidden p-2 text-slate-500" onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}>
-            {isMobileMenuOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
+          {user && (
+            <div className="hidden md:flex items-center gap-3">
+              <div className="text-right">
+                <p className="text-sm font-medium text-slate-700">
+                  {user.full_name ?? user.username}
+                </p>
+                <p className="text-xs text-slate-400 capitalize">{user.role}</p>
+              </div>
+              <button
+                onClick={logout}
+                className="p-2 text-slate-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+                title="Sign out"
+              >
+                <LogOut className="w-4 h-4" />
+              </button>
+            </div>
+          )}
+          <button
+            className="md:hidden p-2 text-slate-500"
+            onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+          >
+            {isMobileMenuOpen ? (
+              <X className="w-6 h-6" />
+            ) : (
+              <Menu className="w-6 h-6" />
+            )}
           </button>
         </div>
       </header>
@@ -64,8 +93,8 @@ export function Layout() {
         {/* Sidebar Navigation */}
         <aside
           className={cn(
-            'fixed inset-y-14 left-0 z-40 w-64 bg-white border-r border-slate-200 transform transition-transform duration-200 ease-in-out md:translate-x-0 md:static',
-            isMobileMenuOpen ? 'translate-x-0' : '-translate-x-full',
+            "fixed inset-y-14 left-0 z-40 w-64 bg-white border-r border-slate-200 transform transition-transform duration-200 ease-in-out md:translate-x-0 md:static",
+            isMobileMenuOpen ? "translate-x-0" : "-translate-x-full",
           )}
         >
           <nav className="p-4 space-y-1">
@@ -75,27 +104,45 @@ export function Layout() {
                 to={item.href}
                 className={({ isActive }) =>
                   cn(
-                    'flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-all group',
-                    isActive ? 'bg-indigo-50 text-indigo-700 shadow-sm' : 'text-slate-600 hover:bg-slate-50 hover:text-slate-900',
+                    "flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-all group",
+                    isActive
+                      ? "bg-indigo-50 text-indigo-700 shadow-sm"
+                      : "text-slate-600 hover:bg-slate-50 hover:text-slate-900",
                   )
                 }
                 onClick={() => setIsMobileMenuOpen(false)}
               >
-                <item.icon className={cn('w-5 h-5 transition-colors', 'group-hover:text-indigo-600')} />
+                <item.icon
+                  className={cn(
+                    "w-5 h-5 transition-colors",
+                    "group-hover:text-indigo-600",
+                  )}
+                />
                 {item.name}
               </NavLink>
             ))}
           </nav>
 
-          <div className="absolute bottom-0 left-0 right-0 p-4 border-t border-slate-100">
+          <div className="absolute bottom-0 left-0 right-0 p-4 border-t border-slate-100 space-y-3">
             <div className="bg-slate-50 rounded-lg p-3">
-              <p className="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-2">Current Program</p>
+              <p className="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-2">
+                Current Program
+              </p>
               <select className="w-full bg-white border border-slate-200 rounded px-2 py-1 text-xs font-medium focus:ring-1 focus:ring-indigo-500 outline-none">
                 <option>Medicare Part B</option>
                 <option>Medicaid State - NY</option>
                 <option>Medicaid State - CA</option>
               </select>
             </div>
+            {user && (
+              <button
+                onClick={logout}
+                className="flex items-center gap-2 w-full px-3 py-2 text-sm text-slate-600 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors md:hidden"
+              >
+                <LogOut className="w-4 h-4" />
+                Sign out ({user.username})
+              </button>
+            )}
           </div>
         </aside>
 

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,0 +1,18 @@
+import { Navigate, Outlet } from "react-router-dom";
+import { useAuth } from "../contexts/AuthContext";
+
+export function ProtectedRoute() {
+  const { isAuthenticated, isLoading } = useAuth();
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-slate-50 flex items-center justify-center">
+        <div className="w-8 h-8 border-4 border-indigo-600 border-t-transparent rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) return <Navigate to="/login" replace />;
+
+  return <Outlet />;
+}

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,0 +1,64 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  useCallback,
+} from "react";
+import type { ReactNode } from "react";
+import {
+  login as apiLogin,
+  getMe,
+  setToken,
+  clearToken,
+  getToken,
+} from "../lib/api";
+import type { AuthUser } from "../lib/api";
+
+interface AuthContextValue {
+  user: AuthUser | null;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  login: (username: string, password: string) => Promise<void>;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [isLoading, setIsLoading] = useState(() => !!getToken());
+
+  useEffect(() => {
+    if (!isLoading) return;
+    getMe()
+      .then(setUser)
+      .catch(() => clearToken())
+      .finally(() => setIsLoading(false));
+  }, [isLoading]);
+
+  const login = useCallback(async (username: string, password: string) => {
+    const resp = await apiLogin(username, password);
+    setToken(resp.access_token);
+    setUser(resp.user);
+  }, []);
+
+  const logout = useCallback(() => {
+    clearToken();
+    setUser(null);
+  }, []);
+
+  return (
+    <AuthContext.Provider
+      value={{ user, isAuthenticated: !!user, isLoading, login, logout }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error("useAuth must be used within AuthProvider");
+  return ctx;
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3,20 +3,50 @@
  * All calls target the deployed backend at VITE_API_BASE_URL.
  */
 
-const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '';
+const API_BASE = import.meta.env.VITE_API_BASE_URL ?? "";
 
-type JsonInit = Omit<RequestInit, 'body'> & { body?: unknown };
+/* ── Auth token management ─────────────────────────────────── */
+
+const TOKEN_KEY = "argus_token";
+
+export function getToken(): string | null {
+  return localStorage.getItem(TOKEN_KEY);
+}
+
+export function setToken(token: string): void {
+  localStorage.setItem(TOKEN_KEY, token);
+}
+
+export function clearToken(): void {
+  localStorage.removeItem(TOKEN_KEY);
+}
+
+/* ── Core request helper ───────────────────────────────────── */
+
+type JsonInit = Omit<RequestInit, "body"> & { body?: unknown };
 
 async function request<T>(path: string, init?: JsonInit): Promise<T> {
   const url = `${API_BASE}${path}`;
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    ...((init?.headers as Record<string, string>) ?? {}),
+  };
+  const token = getToken();
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+
   const response = await fetch(url, {
     ...init,
-    headers: {
-      'Content-Type': 'application/json',
-      ...(init?.headers ?? {}),
-    },
+    headers,
     body: init?.body === undefined ? undefined : JSON.stringify(init.body),
   });
+
+  if (response.status === 401) {
+    clearToken();
+    window.location.href = "/login";
+    throw new Error("Session expired");
+  }
 
   if (!response.ok) {
     const text = await response.text();
@@ -28,9 +58,9 @@ async function request<T>(path: string, init?: JsonInit): Promise<T> {
 
 /* ── Types matching OpenAPI schema ──────────────────────────── */
 
-export type RiskBand = 'stable' | 'review' | 'high_risk';
-export type CaseAction = 'APPROVED' | 'FLAGGED' | 'DENIED' | 'ESCALATED';
-export type Recommendation = 'approve' | 'review' | 'deny';
+export type RiskBand = "stable" | "review" | "high_risk";
+export type CaseAction = "APPROVED" | "FLAGGED" | "DENIED" | "ESCALATED";
+export type Recommendation = "approve" | "review" | "deny";
 
 export interface PaginationMeta {
   total: number;
@@ -289,7 +319,7 @@ export interface NetworkRiskResponse {
 }
 
 export interface ChatMessage {
-  role: 'user' | 'assistant';
+  role: "user" | "assistant";
   content: string;
 }
 
@@ -304,7 +334,7 @@ export interface ChatResponse {
 }
 
 export interface ChartSpec {
-  type: 'bar' | 'line' | 'pie';
+  type: "bar" | "line" | "pie";
   title: string;
   xKey?: string;
   yKey?: string;
@@ -389,15 +419,15 @@ export interface ValidationReport {
 /* ── API functions ──────────────────────────────────────────── */
 
 export function getHealth() {
-  return request<HealthResponse>('/health');
+  return request<HealthResponse>("/health");
 }
 
 export function getDashboard() {
-  return request<DashboardStats>('/api/dashboard');
+  return request<DashboardStats>("/api/dashboard");
 }
 
 export function getHeatmap() {
-  return request<HeatmapResponse>('/api/dashboard/heatmap');
+  return request<HeatmapResponse>("/api/dashboard/heatmap");
 }
 
 export function getProviders(params?: {
@@ -409,13 +439,13 @@ export function getProviders(params?: {
   risk_band?: string;
 }) {
   const search = new URLSearchParams();
-  if (params?.page) search.set('page', String(params.page));
-  if (params?.per_page) search.set('per_page', String(params.per_page));
-  if (params?.q) search.set('q', params.q);
-  if (params?.state) search.set('state', params.state);
-  if (params?.provider_type) search.set('provider_type', params.provider_type);
-  if (params?.risk_band) search.set('risk_band', params.risk_band);
-  const suffix = search.toString() ? `?${search.toString()}` : '';
+  if (params?.page) search.set("page", String(params.page));
+  if (params?.per_page) search.set("per_page", String(params.per_page));
+  if (params?.q) search.set("q", params.q);
+  if (params?.state) search.set("state", params.state);
+  if (params?.provider_type) search.set("provider_type", params.provider_type);
+  if (params?.risk_band) search.set("risk_band", params.risk_band);
+  const suffix = search.toString() ? `?${search.toString()}` : "";
   return request<ProviderListResponse>(`/api/providers${suffix}`);
 }
 
@@ -454,15 +484,15 @@ export function getClaims(params?: {
   risk_max?: number;
 }) {
   const search = new URLSearchParams();
-  if (params?.page) search.set('page', String(params.page));
-  if (params?.per_page) search.set('per_page', String(params.per_page));
-  if (params?.npi) search.set('npi', params.npi);
-  if (params?.case_label) search.set('case_label', params.case_label);
-  if (params?.state) search.set('state', params.state);
-  if (params?.provider_type) search.set('provider_type', params.provider_type);
-  if (params?.risk_min != null) search.set('risk_min', String(params.risk_min));
-  if (params?.risk_max != null) search.set('risk_max', String(params.risk_max));
-  const suffix = search.toString() ? `?${search.toString()}` : '';
+  if (params?.page) search.set("page", String(params.page));
+  if (params?.per_page) search.set("per_page", String(params.per_page));
+  if (params?.npi) search.set("npi", params.npi);
+  if (params?.case_label) search.set("case_label", params.case_label);
+  if (params?.state) search.set("state", params.state);
+  if (params?.provider_type) search.set("provider_type", params.provider_type);
+  if (params?.risk_min != null) search.set("risk_min", String(params.risk_min));
+  if (params?.risk_max != null) search.set("risk_max", String(params.risk_max));
+  const suffix = search.toString() ? `?${search.toString()}` : "";
   return request<ClaimListResponse>(`/api/claims${suffix}`);
 }
 
@@ -471,37 +501,43 @@ export function getClaim(caseId: string) {
 }
 
 export function simulateClaim(payload: ClaimSimulationRequest) {
-  return request<ClaimSimulationResult>('/api/claims/simulate', {
-    method: 'POST',
+  return request<ClaimSimulationResult>("/api/claims/simulate", {
+    method: "POST",
     body: payload,
   });
 }
 
-export function scoreClaim(payload: { npi: string; hcpcs_cd?: string; tot_srvcs?: number; avg_submitted_charge?: number }) {
-  return request<ScoreResult>('/api/score', {
-    method: 'POST',
+export function scoreClaim(payload: {
+  npi: string;
+  hcpcs_cd?: string;
+  tot_srvcs?: number;
+  avg_submitted_charge?: number;
+}) {
+  return request<ScoreResult>("/api/score", {
+    method: "POST",
     body: payload,
   });
 }
 
 export function getFairness(params?: { threshold?: number; blind?: boolean }) {
   const search = new URLSearchParams();
-  if (params?.threshold != null) search.set('threshold', String(params.threshold));
-  if (params?.blind != null) search.set('blind', String(params.blind));
-  const suffix = search.toString() ? `?${search.toString()}` : '';
+  if (params?.threshold != null)
+    search.set("threshold", String(params.threshold));
+  if (params?.blind != null) search.set("blind", String(params.blind));
+  const suffix = search.toString() ? `?${search.toString()}` : "";
   return request<FairnessReport>(`/api/fairness${suffix}`);
 }
 
 export function chat(message: string, history: ChatMessage[] = []) {
-  return request<ChatResponse>('/api/chat', {
-    method: 'POST',
+  return request<ChatResponse>("/api/chat", {
+    method: "POST",
     body: { message, history },
   });
 }
 
 export function caseAction(caseId: string, action: CaseAction, notes?: string) {
   return request<CaseActionResponse>(`/api/cases/${caseId}/action`, {
-    method: 'POST',
+    method: "POST",
     body: { action, notes },
   });
 }
@@ -515,5 +551,31 @@ export function getPendingCases(limit = 50) {
 }
 
 export function getValidation() {
-  return request<ValidationReport>('/api/validation');
+  return request<ValidationReport>("/api/validation");
+}
+
+/* ── Auth ──────────────────────────────────────────────────── */
+
+export interface AuthUser {
+  id: number;
+  username: string;
+  role: string;
+  full_name: string | null;
+}
+
+export interface TokenResponse {
+  access_token: string;
+  token_type: string;
+  user: AuthUser;
+}
+
+export function login(username: string, password: string) {
+  return request<TokenResponse>("/api/auth/login", {
+    method: "POST",
+    body: { username, password },
+  });
+}
+
+export function getMe() {
+  return request<AuthUser>("/api/auth/me");
 }

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,0 +1,96 @@
+import { useState } from "react";
+import { Navigate } from "react-router-dom";
+import { useAuth } from "../contexts/AuthContext";
+
+export function Login() {
+  const { login, isAuthenticated } = useAuth();
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  if (isAuthenticated) return <Navigate to="/" replace />;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+    try {
+      await login(username, password);
+    } catch {
+      setError("Invalid username or password");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-slate-50 flex items-center justify-center p-4">
+      <div className="w-full max-w-sm">
+        <div className="text-center mb-8">
+          <div className="w-12 h-12 bg-indigo-600 rounded-xl flex items-center justify-center text-white font-bold text-2xl mx-auto mb-4">
+            A
+          </div>
+          <h1 className="text-2xl font-bold text-slate-800">Argus</h1>
+          <p className="text-sm text-slate-500 mt-1">
+            CMS Fraud Detection Platform
+          </p>
+        </div>
+
+        <form
+          onSubmit={handleSubmit}
+          className="bg-white rounded-xl shadow-sm border border-slate-200 p-6 space-y-4"
+        >
+          {error && (
+            <div className="bg-red-50 text-red-700 text-sm px-3 py-2 rounded-lg border border-red-200">
+              {error}
+            </div>
+          )}
+
+          <div>
+            <label
+              htmlFor="username"
+              className="block text-sm font-medium text-slate-700 mb-1"
+            >
+              Username
+            </label>
+            <input
+              id="username"
+              type="text"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              className="w-full px-3 py-2 border border-slate-300 rounded-lg text-sm focus:ring-2 focus:ring-indigo-200 focus:border-indigo-500 outline-none"
+              required
+              autoFocus
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="password"
+              className="block text-sm font-medium text-slate-700 mb-1"
+            >
+              Password
+            </label>
+            <input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="w-full px-3 py-2 border border-slate-300 rounded-lg text-sm focus:ring-2 focus:ring-indigo-200 focus:border-indigo-500 outline-none"
+              required
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full bg-indigo-600 text-white py-2 rounded-lg text-sm font-medium hover:bg-indigo-700 disabled:opacity-50 transition-colors"
+          >
+            {loading ? "Signing in..." : "Sign in"}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #289

- **Login page** (`/login`) with username/password form, error handling, and loading state
- **AuthContext** with JWT token management (localStorage), auto-validation on mount via `/api/auth/me`
- **ProtectedRoute** wrapper redirects unauthenticated users to `/login`
- **App.tsx** wraps all routes in `AuthProvider`; `/login` is public, all other routes protected
- **Layout.tsx** shows user name/role and logout button in header (desktop + mobile)
- **API client** sends `Bearer` token on all requests, auto-redirects to `/login` on 401

## Test plan

- [ ] Navigate to any page without token — redirected to `/login`
- [ ] Login with valid credentials (admin/argus-admin-2026) — redirected to dashboard
- [ ] Verify user name and role shown in header
- [ ] Click logout — redirected to `/login`, token cleared
- [ ] Login with bad credentials — error message shown
- [ ] Refresh page while logged in — stays logged in (token validated via `/me`)
- [ ] CI passes: eslint, tsc, vite build