### PR TITLE
fix(api): tighten CORS to production domain (#297)

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from contextlib import asynccontextmanager
 
 from fastapi import Depends, FastAPI
@@ -33,9 +34,14 @@ def create_app() -> FastAPI:
         lifespan=lifespan,
     )
 
+    cors_origins = os.getenv(
+        "CORS_ORIGINS",
+        "https://argus.precise-lab.com,http://localhost:3000",
+    ).split(",")
+
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],  # tighten for prod
+        allow_origins=cors_origins,
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],


### PR DESCRIPTION
## Summary
- Replace wildcard `allow_origins=["*"]` with env-configurable CORS origins
- Default: `https://argus.precise-lab.com,http://localhost:3000`
- Configurable via `CORS_ORIGINS` env var (comma-separated)

## Changes
- `src/api/app.py`: Read origins from `CORS_ORIGINS` env var with sensible defaults

## Test Plan
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `mypy` passes
- [ ] CI pipeline passes
- [ ] Deployed app at `argus.precise-lab.com` still loads (CORS headers match)
- [ ] Local dev with `localhost:3000` still works

Closes #297