### PR TITLE
fix(docs): correct tech stack references from Next.js to Vite + React 19 (#298)

### DIFF
--- a/.github/agents/bug-fixer.agent.md
+++ b/.github/agents/bug-fixer.agent.md
@@ -14,7 +14,7 @@ You are the Bug Fixer agent for the Argus CMS Fraud Detection project — a proa
 - **AI Layer**: AWS Bedrock Claude (`src/ai/`) — `text_to_sql.py` (NL→SQL), `narrative.py` (risk briefs), `bedrock.py` (client)
 - **Pipeline**: Polars feature engineering (`src/pipeline/build_features.py`)
 - **Data**: psycopg COPY bulk loader (`src/data/load_postgres.py`)
-- **Frontend**: Next.js 16 + Tailwind v4 + shadcn/ui (`frontend/`)
+- **Frontend**: Vite + React 19 + Tailwind v4 + shadcn/ui (`frontend/`)
 - **DB**: PostgreSQL 16 (`provider_features` 63 cols, `provider_service_cases`) + Neo4j 5 (network risk)
 - **Tests**: 24 test files in `tests/`, all use mocks — no live DB connections
 

--- a/.github/agents/code-reviewer.agent.md
+++ b/.github/agents/code-reviewer.agent.md
@@ -17,7 +17,7 @@ Identifies anomalous Medicare billing patterns using peer comparison, determinis
 - **Scoring**: Deterministic rule engine (`src/scoring/`) — `taxonomy.py` (signals/weights), `score.py`, `extract.py`
 - **AI Layer**: AWS Bedrock Claude (`src/ai/`) — `text_to_sql.py` (NL→SQL with guardrails), `narrative.py` (risk briefs), `bedrock.py` (client)
 - **Pipeline**: Polars feature engineering (`src/pipeline/build_features.py`)
-- **Frontend**: Next.js 16 + Tailwind v4 + shadcn/ui + Recharts (`frontend/`)
+- **Frontend**: Vite + React 19 + Tailwind v4 + shadcn/ui + Recharts (`frontend/`)
 - **DB**: PostgreSQL 16 (`provider_features` 63 cols, `provider_service_cases`) + Neo4j 5 (network risk)
 - **Tests**: pytest + pytest-asyncio in `tests/` — 24 test files, all mocked (no live DB)
 

--- a/.github/agents/docs-writer.agent.md
+++ b/.github/agents/docs-writer.agent.md
@@ -17,7 +17,7 @@ Identifies anomalous Medicare billing patterns using peer comparison, determinis
 - **Scoring**: Deterministic rule engine (`src/scoring/`) — 14 signals in `taxonomy.py`
 - **AI Layer**: AWS Bedrock Claude (`src/ai/`) — text-to-SQL (Haiku 4.5), risk narratives (Sonnet 4.6)
 - **Pipeline**: Polars feature engineering (`src/pipeline/build_features.py`)
-- **Frontend**: Next.js 16 + Tailwind v4 + shadcn/ui + Recharts (`frontend/`)
+- **Frontend**: Vite + React 19 + Tailwind v4 + shadcn/ui + Recharts (`frontend/`)
 - **DB**: PostgreSQL 16 + Neo4j 5
 - **Infra**: EKS + ArgoCD + Terraform, deployed at `argus.precise-lab.com`
 

--- a/.github/agents/security-auditor.agent.md
+++ b/.github/agents/security-auditor.agent.md
@@ -25,7 +25,7 @@ Identifies anomalous Medicare billing patterns using peer comparison, determinis
   - `narrative.py` — risk narrative generation (output displayed to users)
 - **Scoring** (`src/scoring/`) — deterministic, no AI involvement in scoring logic
 - **DB**: PostgreSQL 16 (psycopg parameterized queries) + Neo4j 5 (bolt protocol)
-- **Frontend**: Next.js 16 (`frontend/`) — server components, API calls via `fetch`
+- **Frontend**: Vite + React 19 (`frontend/`) — server components, API calls via `fetch`
 
 ### Known Security Decisions
 

--- a/.github/agents/senior-developer.agent.md
+++ b/.github/agents/senior-developer.agent.md
@@ -50,7 +50,7 @@ Implement features and enhancements from issue requirements. You write productio
 - **Validation**: Retrospective testing (`src/validation/`)
 - **Models**: ML models like Isolation Forest (`src/models/`)
 
-### Frontend (Next.js 16 + TypeScript)
+### Frontend (Vite + React 19 + TypeScript)
 
 - Located in `frontend/`
 - Tailwind v4 + shadcn/ui + Recharts + react-force-graph-2d

--- a/.github/agents/technical-pm.agent.md
+++ b/.github/agents/technical-pm.agent.md
@@ -84,7 +84,7 @@ When asked to plan a sprint or batch of work:
 ### Architecture
 
 - **Backend**: FastAPI + psycopg + Polars (Python 3.12+)
-- **Frontend**: Next.js 16 + Tailwind v4 + shadcn/ui
+- **Frontend**: Vite + React 19 + Tailwind v4 + shadcn/ui
 - **DB**: PostgreSQL 16 + Neo4j 5
 - **AI**: AWS Bedrock Claude (text-to-SQL, risk narratives)
 - **Infra**: EKS + ArgoCD + Terraform

--- a/.github/agents/test-engineer.agent.md
+++ b/.github/agents/test-engineer.agent.md
@@ -20,7 +20,7 @@ Identifies anomalous Medicare billing patterns using peer comparison, determinis
 - **Data**: psycopg COPY bulk loader (`src/data/load_postgres.py`)
 - **Models**: Isolation Forest anomaly detection (`src/models/anomaly.py`)
 - **Validation**: Retrospective testing (`src/validation/retrospective.py`)
-- **Frontend**: Next.js 16 (`frontend/`) — not tested by Python CI
+- **Frontend**: Vite + React 19 (`frontend/`) — not tested by Python CI
 
 ### External Dependencies to Mock
 

--- a/docs/agile/2026-03-23-scorecard.md
+++ b/docs/agile/2026-03-23-scorecard.md
@@ -169,18 +169,18 @@
 
 ## Architecture
 
-| Component      | Technology                           | Deployment            |
-| -------------- | ------------------------------------ | --------------------- |
-| API            | FastAPI + async psycopg pool         | EKS, 2 replicas       |
-| Frontend       | Next.js 16 + Tailwind v4 + shadcn/ui | EKS, 2 replicas       |
-| Database       | PostgreSQL 16                        | EKS StatefulSet, 20Gi |
-| Graph          | Neo4j 5 Community                    | EKS StatefulSet, 10Gi |
-| AI (chat)      | Claude Haiku 4.5 via Bedrock         | us-east-1             |
-| AI (narrative) | Claude Sonnet 4.6 via Bedrock        | us-east-1             |
-| ML             | Isolation Forest (scikit-learn)      | Bundled in API image  |
-| CI/CD          | GitHub Actions + ArgoCD              | 7 workflows           |
-| Infra          | Terraform + EKS                      | us-east-1             |
-| Domain         | argus.precise-lab.com                | Route53 + Istio NLB   |
+| Component      | Technology                      | Deployment            |
+| -------------- | ------------------------------- | --------------------- |
+| API            | FastAPI + async psycopg pool    | EKS, 2 replicas       |
+| Frontend       | Vite + React 19 + Tailwind v4   | EKS, 2 replicas       |
+| Database       | PostgreSQL 16                   | EKS StatefulSet, 20Gi |
+| Graph          | Neo4j 5 Community               | EKS StatefulSet, 10Gi |
+| AI (chat)      | Claude Haiku 4.5 via Bedrock    | us-east-1             |
+| AI (narrative) | Claude Sonnet 4.6 via Bedrock   | us-east-1             |
+| ML             | Isolation Forest (scikit-learn) | Bundled in API image  |
+| CI/CD          | GitHub Actions + ArgoCD         | 7 workflows           |
+| Infra          | Terraform + EKS                 | us-east-1             |
+| Domain         | argus.precise-lab.com           | Route53 + Istio NLB   |
 
 ---
 

--- a/docs/architecture-v3.md
+++ b/docs/architecture-v3.md
@@ -825,7 +825,7 @@ capabilities. Production-ready with proper error handling, CORS, health checks.
 
 ## Epic 6: Frontend — Dashboard, Claims Simulator, Fairness
 
-**Goal**: Next.js frontend with three views: (1) overview dashboard with risk heatmap,
+**Goal**: React frontend with three views: (1) overview dashboard with risk heatmap,
 (2) claims simulator with scoring and transparency, (3) fairness dashboard proving
 responsible AI. Provider search available from every view.
 
@@ -851,7 +851,7 @@ responsible AI. Provider search available from every view.
 
 **Stories**:
 
-1. Scaffold Next.js 16 + TypeScript + shadcn/ui project
+1. Scaffold Vite + React 19 + TypeScript project
 2. Build overview dashboard page (stat cards, top flagged list)
 3. Build risk heatmap component (US choropleth map)
 4. Build provider search with autocomplete

--- a/docs/diagrams/01-system-architecture.mmd
+++ b/docs/diagrams/01-system-architecture.mmd
@@ -1,7 +1,7 @@
 %%{init: {'theme': 'base', 'themeVariables': {'primaryColor': '#e2e8f0', 'primaryTextColor': '#1e293b', 'primaryBorderColor': '#94a3b8', 'lineColor': '#64748b', 'secondaryColor': '#f1f5f9', 'tertiaryColor': '#f8fafc', 'fontFamily': 'Inter, system-ui, sans-serif'}}}%%
 
 graph TB
-    subgraph Frontend["Frontend — Next.js 16 + TypeScript + shadcn/ui"]
+    subgraph Frontend["Frontend — Vite + React 19 + TypeScript + Tailwind v4"]
         direction LR
         DASH["Dashboard<br/><i>Overview + Heatmap</i>"]
         CLAIMS["Claims Simulator<br/><i>Score + Signals + Drill-down</i>"]

--- a/docs/diagrams/02-deployment-architecture.mmd
+++ b/docs/diagrams/02-deployment-architecture.mmd
@@ -23,7 +23,7 @@ graph LR
     subgraph EKS["Amazon EKS Cluster"]
         direction TB
         subgraph NS["Namespace: cms-fraud-detection"]
-            FE_DEP["Frontend<br/><i>Next.js standalone<br/>2 replicas</i>"]
+            FE_DEP["Frontend<br/><i>Vite + React 19<br/>2 replicas</i>"]
             BE_DEP["Backend<br/><i>FastAPI + Uvicorn<br/>2 replicas</i>"]
             PG_SS["PostgreSQL 16<br/><i>StatefulSet + PVC</i>"]
             NEO_SS["Neo4j 5<br/><i>StatefulSet + PVC</i>"]

--- a/docs/diagrams/06-ai-reasoning.mmd
+++ b/docs/diagrams/06-ai-reasoning.mmd
@@ -2,7 +2,7 @@
 
 sequenceDiagram
     participant U as User
-    participant FE as Frontend<br/>Next.js
+    participant FE as Frontend<br/>React
     participant API as FastAPI<br/>Backend
     participant LLM as AWS Bedrock<br/>Claude Sonnet
     participant DB as PostgreSQL


### PR DESCRIPTION
## Summary
- Replace stale "Next.js 16" references with actual stack: **Vite + React 19 + Tailwind v4**
- 12 files updated across docs, Mermaid diagrams, and GitHub agent configs

## Files Changed
- `docs/architecture-v3.md` — Epic 6 goal and story #1
- `docs/agile/2026-03-23-scorecard.md` — Architecture table
- `docs/diagrams/01-system-architecture.mmd` — Frontend subgraph label
- `docs/diagrams/02-deployment-architecture.mmd` — Frontend deployment label
- `docs/diagrams/06-ai-reasoning.mmd` — Sequence diagram participant
- `.github/agents/*.agent.md` — 7 agent config files

## Not Changed (intentional)
- Historical agile scorecards (Mar 15-18) — point-in-time records
- `docs/SPRINT-PLAN.md` — historical planning doc
- `README.md` — already correct

## Test Plan
- [x] No stale Next.js references in current-facing docs
- [x] Historical records preserved
- [ ] CI passes

Closes #298