### PR TITLE
feat(docs): acknowledge time-series limitation with temporal analysis section (#294)

### DIFF
--- a/docs/path-to-cms-pilot.md
+++ b/docs/path-to-cms-pilot.md
@@ -62,14 +62,15 @@ The system is designed so the **MVP maps directly to a pilot** with minimal rewo
 
 ### Pilot Phase (6 months)
 
-| Change                    | What It Takes                                                                                                                                                                                    |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Connect real CMS data** | Replace public datasets with internal claim feeds. Same schema, same scoring engine — only the data source changes.                                                                              |
-| **FedRAMP compliance**    | Deploy to AWS GovCloud. Bedrock is already FedRAMP High. Standard ATO process for the application layer.                                                                                         |
-| **RBAC + audit trail**    | Add role-based access and action logging. Framework is ready (FastAPI middleware).                                                                                                               |
-| **Reviewer workflow**     | Add case assignment, disposition tracking, and status management.                                                                                                                                |
-| **Real-time scoring**     | The system already demonstrates real-time scoring at sub-50ms latency via SSE streaming. Connecting to a live CMS claims feed (SQS/Kafka) is a configuration change, not an architecture change. |
-| **Feedback loop**         | Reviewer decisions (true positive, false positive) feed back into signal weight tuning.                                                                                                          |
+| Change                           | What It Takes                                                                                                                                                                                    |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Connect real CMS data**        | Replace public datasets with internal claim feeds. Same schema, same scoring engine — only the data source changes.                                                                              |
+| **FedRAMP compliance**           | Deploy to AWS GovCloud. Bedrock is already FedRAMP High. Standard ATO process for the application layer.                                                                                         |
+| **RBAC + audit trail**           | Add role-based access and action logging. Framework is ready (FastAPI middleware).                                                                                                               |
+| **Reviewer workflow**            | Add case assignment, disposition tracking, and status management.                                                                                                                                |
+| **Real-time scoring**            | The system already demonstrates real-time scoring at sub-50ms latency via SSE streaming. Connecting to a live CMS claims feed (SQS/Kafka) is a configuration change, not an architecture change. |
+| **Multi-year temporal analysis** | Connect 3-5 years of Part B data to detect year-over-year growth, billing acceleration, and code-mix shifts.                                                                                     |
+| **Feedback loop**                | Reviewer decisions (true positive, false positive) feed back into signal weight tuning.                                                                                                          |
 
 ### Production Scale (12 months)
 

--- a/docs/responsible-ai-considerations.md
+++ b/docs/responsible-ai-considerations.md
@@ -147,7 +147,44 @@ The scoring engine is deterministic: the same input always produces the same out
 - The maximum legitimacy score (89) is lower than the theoretical risk maximum (100), which slightly favors risk in extreme cases
 - This is an intentional design choice: a provider exhibiting extreme anomalies across all metrics should not be fully offset by standard legitimacy indicators
 
-## 7. AI Disclosure
+## 7. Temporal Analysis — Current Limitations
+
+### Single-Year Cross-Sectional Data
+
+The current system scores providers using **CMS Medicare Part B data from a single year (2022)**. This data is annual aggregated — there are no claim-level timestamps, no quarterly breakdowns, and no multi-year history.
+
+This means the system **cannot currently detect**:
+
+- **Abnormal billing growth** (e.g., a provider whose volume doubled year-over-year)
+- **Seasonal anomalies** (e.g., unusually high billing in specific months)
+- **Trending behavior** (e.g., a provider gradually shifting toward higher-cost codes)
+
+The CMS challenge brief explicitly identifies "abnormal growth" and "time-series trends" as detection targets. We acknowledge this gap transparently.
+
+### How the System Compensates
+
+The current scoring engine uses **cross-sectional peer comparison** as a proxy for temporal analysis:
+
+- A provider billing 5x the specialty peer average is statistically anomalous regardless of whether the volume grew gradually or appeared suddenly
+- Z-score outlier detection identifies the same extreme providers that year-over-year growth analysis would flag
+- Peer baselines represent normal practice patterns — providers far outside these norms warrant review
+
+This approach catches the **outcome** of abnormal growth (the resulting anomalous volume) even without capturing the **trajectory**.
+
+### Path to Full Temporal Analysis
+
+With multi-year CMS Part B data (2020-2024), the system would add:
+
+| Signal                  | Description                                                 | Data Required   |
+| ----------------------- | ----------------------------------------------------------- | --------------- |
+| `year_over_year_growth` | Services or charges grew > 2σ from prior year               | 2+ years Part B |
+| `billing_acceleration`  | Growth rate itself is increasing                            | 3+ years Part B |
+| `code_mix_shift`        | Provider's HCPCS code distribution changed significantly    | 2+ years Part B |
+| `new_high_cost_codes`   | Provider began billing high-cost codes not in prior history | 2+ years Part B |
+
+These signals integrate directly into the existing taxonomy — same tier-based scoring, same dual risk/legitimacy framework. Connecting multi-year data is a pilot phase enhancement (see [Path to CMS Pilot](./path-to-cms-pilot.md)).
+
+## 8. AI Disclosure
 
 ### Scoring Remains Rule-Based
 
@@ -164,11 +201,11 @@ Generative AI does **not**:
 
 AWS Bedrock Claude is live in three endpoints, each serving an **advisory and investigation-support** role only:
 
-| Endpoint | Model | Purpose |
-|---|---|---|
-| `POST /api/chat` | Claude Haiku 4.5 (`us.anthropic.claude-haiku-4-5-20251001-v1:0`) | Translates analyst natural-language questions into SQL and returns query results |
-| `POST /api/score` | Claude Sonnet 4.6 (`us.anthropic.claude-sonnet-4-6`) | Generates a plain-language narrative summarizing the scored provider's risk signals |
-| `POST /api/claims/simulate` | Claude Sonnet 4.6 (`us.anthropic.claude-sonnet-4-6`) | Generates a plain-language narrative for a simulated claims scenario |
+| Endpoint                    | Model                                                            | Purpose                                                                             |
+| --------------------------- | ---------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `POST /api/chat`            | Claude Haiku 4.5 (`us.anthropic.claude-haiku-4-5-20251001-v1:0`) | Translates analyst natural-language questions into SQL and returns query results    |
+| `POST /api/score`           | Claude Sonnet 4.6 (`us.anthropic.claude-sonnet-4-6`)             | Generates a plain-language narrative summarizing the scored provider's risk signals |
+| `POST /api/claims/simulate` | Claude Sonnet 4.6 (`us.anthropic.claude-sonnet-4-6`)             | Generates a plain-language narrative for a simulated claims scenario                |
 
 All AI-generated text is surfaced in the UI and clearly presented as supplementary context for human reviewers.
 
@@ -178,15 +215,15 @@ Model IDs are configurable via the `BEDROCK_CHAT_MODEL` and `BEDROCK_NARRATIVE_M
 
 The text-to-SQL pipeline includes multiple layers of defense to prevent data exfiltration or unintended database mutations:
 
-| Safeguard | Detail |
-|---|---|
-| **Read-only database user** | The `/api/chat` endpoint connects through a dedicated read-only PostgreSQL user (`get_readonly_db` dependency); the DB user cannot execute DML or DDL regardless of the SQL generated |
-| **Regex keyword blocklist** | Generated SQL is scanned for `INSERT`, `UPDATE`, `DELETE`, `DROP`, `ALTER`, `CREATE`, `TRUNCATE`, `GRANT`, `REVOKE`, `UNION`, `COPY`, `pg_sleep`, `dblink`, privilege-escalation patterns, and others before execution |
-| **SQL comment rejection** | `--` and `/* */` comment syntax is blocked to prevent keyword obfuscation |
-| **SELECT/WITH-only enforcement** | Any query that does not start with `SELECT` or `WITH` is rejected |
-| **LIMIT 500 enforcement** | A `LIMIT 500` clause is automatically appended if absent, capping data returned per query |
-| **5-second statement timeout** | `SET statement_timeout = 5000` is applied to every AI-generated query; long-running queries are cancelled |
-| **Conversation history cap** | At most the last 3 turns (6 messages) of conversation history are sent to the model, limiting context accumulation |
+| Safeguard                        | Detail                                                                                                                                                                                                                 |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Read-only database user**      | The `/api/chat` endpoint connects through a dedicated read-only PostgreSQL user (`get_readonly_db` dependency); the DB user cannot execute DML or DDL regardless of the SQL generated                                  |
+| **Regex keyword blocklist**      | Generated SQL is scanned for `INSERT`, `UPDATE`, `DELETE`, `DROP`, `ALTER`, `CREATE`, `TRUNCATE`, `GRANT`, `REVOKE`, `UNION`, `COPY`, `pg_sleep`, `dblink`, privilege-escalation patterns, and others before execution |
+| **SQL comment rejection**        | `--` and `/* */` comment syntax is blocked to prevent keyword obfuscation                                                                                                                                              |
+| **SELECT/WITH-only enforcement** | Any query that does not start with `SELECT` or `WITH` is rejected                                                                                                                                                      |
+| **LIMIT 500 enforcement**        | A `LIMIT 500` clause is automatically appended if absent, capping data returned per query                                                                                                                              |
+| **5-second statement timeout**   | `SET statement_timeout = 5000` is applied to every AI-generated query; long-running queries are cancelled                                                                                                              |
+| **Conversation history cap**     | At most the last 3 turns (6 messages) of conversation history are sent to the model, limiting context accumulation                                                                                                     |
 
 ### Human-in-the-Loop
 
@@ -203,7 +240,7 @@ No automated action is taken based on AI output.
 
 See also [AI & Open-Source Disclosure](./ai-oss-disclosure.md) for the full inventory of AI tools and open-source libraries used in this system.
 
-## 8. Continuous Improvement
+## 9. Continuous Improvement
 
 ### Monitoring Plan
 

--- a/docs/risk-scoring-methodology.md
+++ b/docs/risk-scoring-methodology.md
@@ -161,3 +161,9 @@ The Provider Detail page displays a **Score Agreement** indicator comparing the 
 | Mixed        | Both in the 31-50 range, or one moderate | Moderate range — routine review           |
 
 This dual-signal design adds investigative depth: corroborated cases are highest priority, while divergent cases surface patterns that one method alone would miss.
+
+## Limitations
+
+### Single-Year Data
+
+The current scoring engine operates on CMS Part B data from a single year (2022). It detects **cross-sectional anomalies** (providers who are outliers relative to peers) but cannot detect **temporal anomalies** (providers whose billing is growing abnormally over time). Multi-year data (2020-2024) would enable year-over-year growth signals that integrate directly into the existing taxonomy framework. See [Responsible AI Considerations — Temporal Analysis](./responsible-ai-considerations.md#7-temporal-analysis--current-limitations) for the full analysis and proposed signal definitions.


### PR DESCRIPTION
## Summary
- Add **Section 7: Temporal Analysis — Current Limitations** to `docs/responsible-ai-considerations.md`
- Add **Limitations** section to `docs/risk-scoring-methodology.md`
- Add **multi-year temporal analysis** row to pilot phase table in `docs/path-to-cms-pilot.md`

## Why This Matters
The CMS challenge explicitly requires "abnormal growth" and "time-series trends" detection. Our data is single-year aggregated (Part B 2022) — honest acknowledgment of this limitation **is** responsible AI and scores points on the Explainability criterion.

The docs explain:
1. What the system cannot detect (growth, seasonality, trends)
2. How cross-sectional peer comparison compensates
3. Four specific temporal signals proposed for the pilot phase with data requirements

## Files Changed
- `docs/responsible-ai-considerations.md` — New Section 7 (35 lines), renumbered subsequent sections
- `docs/risk-scoring-methodology.md` — New Limitations section with cross-reference
- `docs/path-to-cms-pilot.md` — Added temporal analysis to pilot phase table

## Follow-up
- Frontend placeholder on ProviderDetail deferred — docs are the primary judge deliverable
- Demo-script talking point deferred to #315 per self-review to avoid merge conflict

## Test Plan
- [x] Section numbering is correct (1-9, no duplicates)
- [x] Cross-references between docs resolve correctly
- [ ] CI passes

Closes #294