### PR TITLE
feat(api): add SSE endpoint for real-time payment simulation (#313)

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -75,6 +75,11 @@ def create_app() -> FastAPI:
     app.include_router(chat_router, prefix="/api", dependencies=_auth)
     app.include_router(validation_router, prefix="/api", dependencies=_auth)
 
+    # --- Live stream (public — SSE cannot send auth headers) ---
+    from src.api.routes.live import router as live_router
+
+    app.include_router(live_router, prefix="/api")
+
     # --- Health endpoint (no router needed) ---
     from src.api.schemas import HealthResponse
 

--- a/src/api/routes/live.py
+++ b/src/api/routes/live.py
@@ -1,0 +1,139 @@
+"""Real-time payment simulation stream via Server-Sent Events (SSE).
+
+Samples random claims from the database, scores each one live through
+the scoring engine, and streams results to the frontend for the
+Live Payment Monitor demo.
+
+NOTE: No auth on SSE stream — demo-scoped. Production: gate via Istio JWT policy.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import StreamingResponse
+from psycopg import AsyncConnection
+from psycopg.rows import dict_row
+
+from src.api.deps import get_db
+from src.models.anomaly_scorer import score_provider
+from src.scoring.score import score_case
+from src.scoring.taxonomy import SignalDirection
+
+router = APIRouter(prefix="/live", tags=["live"])
+
+# ---------------------------------------------------------------------------
+# SQL — fetch a random claim row with all columns needed for scoring
+# ---------------------------------------------------------------------------
+
+_RANDOM_CLAIM_SQL = """
+SELECT case_id, npi, provider_name, state, city,
+       hcpcs_cd, hcpcs_desc, place_of_service, provider_type,
+       avg_submitted_charge, tot_srvcs, tot_benes,
+       present_in_2025_enrollment_file, present_in_2026_revocation_file,
+       medicare_participating_ind, provider_total_benes,
+       peer_scope, peer_case_count, peer_avg_tot_srvcs,
+       service_volume_peer_z, services_per_bene_peer_z,
+       submitted_to_allowed_peer_z, payment_peer_z,
+       top_code_share, service_hhi
+FROM provider_service_cases
+ORDER BY RANDOM()
+LIMIT 1
+"""
+
+_FEATURES_SQL = """SELECT * FROM provider_features WHERE npi = %s"""
+
+
+# ---------------------------------------------------------------------------
+# SSE stream endpoint
+# ---------------------------------------------------------------------------
+
+
+@router.get("/stream")
+async def stream_claims(
+    conn: AsyncConnection = Depends(get_db),
+    interval: float = Query(default=1.5, ge=0.5, le=5.0),
+    limit: int = Query(default=0, ge=0),
+):
+    """Stream scored claims as Server-Sent Events.
+
+    Each event contains a randomly sampled claim scored in real-time
+    through the 14-signal scoring engine with live latency measurement.
+    """
+
+    async def event_generator():
+        count = 0
+        while limit == 0 or count < limit:
+            try:
+                # 1. Sample a random claim
+                async with conn.cursor(row_factory=dict_row) as cur:
+                    await cur.execute(_RANDOM_CLAIM_SQL)
+                    row = await cur.fetchone()
+
+                if not row:
+                    await asyncio.sleep(interval)
+                    continue
+
+                # 2. Score it live and measure latency
+                start = time.monotonic()
+                card = score_case(dict(row))
+                latency_ms = (time.monotonic() - start) * 1000
+
+                # 3. Get anomaly score (optional, non-fatal)
+                anomaly_score: float | None = None
+                try:
+                    async with conn.cursor(row_factory=dict_row) as cur:
+                        await cur.execute(_FEATURES_SQL, [row["npi"]])
+                        features_row = await cur.fetchone()
+                    if features_row:
+                        anomaly_score = score_provider(features_row)
+                except Exception:
+                    pass
+
+                # 4. Build event payload
+                risk_signals = [
+                    s.signal.name
+                    for s in card.signals
+                    if s.signal.direction == SignalDirection.risk
+                ]
+
+                event = {
+                    "event_id": f"evt_{count:05d}",
+                    "timestamp": datetime.now(UTC).isoformat(),
+                    "npi": row["npi"],
+                    "provider_name": row.get("provider_name") or "Unknown",
+                    "state": row.get("state") or "Unknown",
+                    "city": row.get("city") or "",
+                    "hcpcs_code": row.get("hcpcs_cd") or "",
+                    "hcpcs_desc": row.get("hcpcs_desc") or "",
+                    "submitted_charge": float(row.get("avg_submitted_charge") or 0),
+                    "risk_score": card.risk_score,
+                    "legitimacy_score": card.legitimacy_score,
+                    "case_label": card.case_label.value,
+                    "anomaly_score": anomaly_score,
+                    "signals": risk_signals,
+                    "scoring_latency_ms": round(latency_ms, 1),
+                }
+
+                yield f"data: {json.dumps(event)}\n\n"
+                count += 1
+
+            except Exception:
+                # Connection lost or DB error — stop gracefully
+                break
+
+            await asyncio.sleep(interval)
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -1,0 +1,185 @@
+"""Tests for GET /api/live/stream — SSE endpoint with mocked DB."""
+
+from __future__ import annotations
+
+import json
+from contextlib import asynccontextmanager
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from src.api.deps import get_db
+from src.api.routes.live import router
+
+# ---------------------------------------------------------------------------
+# Fake DB row matching provider_service_cases columns
+# ---------------------------------------------------------------------------
+
+CLAIM_ROW = {
+    "case_id": "C_TEST_001",
+    "npi": "1234567890",
+    "provider_name": "SMITH, JOHN M.D.",
+    "state": "TX",
+    "city": "HOUSTON",
+    "hcpcs_cd": "99213",
+    "hcpcs_desc": "OFFICE/OUTPATIENT VISIT EST",
+    "place_of_service": "11",
+    "provider_type": "Internal Medicine",
+    "avg_submitted_charge": 150.0,
+    "tot_srvcs": 200,
+    "tot_benes": 50,
+    "present_in_2025_enrollment_file": 1,
+    "present_in_2026_revocation_file": 0,
+    "medicare_participating_ind": "Y",
+    "provider_total_benes": 200.0,
+    "peer_scope": "Internal Medicine|99213",
+    "peer_case_count": 100,
+    "peer_avg_tot_srvcs": 120.0,
+    "service_volume_peer_z": 1.5,
+    "services_per_bene_peer_z": 0.8,
+    "submitted_to_allowed_peer_z": 0.5,
+    "payment_peer_z": 0.3,
+    "top_code_share": 0.4,
+    "service_hhi": 0.2,
+}
+
+
+# ---------------------------------------------------------------------------
+# Mock DB connection
+# ---------------------------------------------------------------------------
+
+
+class FakeCursor:
+    """Minimal async cursor that returns CLAIM_ROW then None for features."""
+
+    def __init__(self, row):
+        self._row = row
+        self._call_count = 0
+
+    async def execute(self, sql, params=None):
+        self._call_count += 1
+
+    async def fetchone(self):
+        # First call: random claim. Second call: features (return None).
+        if self._call_count <= 1:
+            return self._row
+        return None
+
+
+class FakeConn:
+    def __init__(self, row):
+        self._row = row
+
+    @asynccontextmanager
+    async def cursor(self, row_factory=None):
+        yield FakeCursor(self._row)
+
+
+def make_fake_db(row=CLAIM_ROW):
+    async def _dep():
+        yield FakeConn(row)
+
+    return _dep
+
+
+# ---------------------------------------------------------------------------
+# App fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def app():
+    _app = FastAPI()
+    _app.include_router(router, prefix="/api")
+    _app.dependency_overrides[get_db] = make_fake_db()
+    return _app
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stream_returns_sse_content_type(app):
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        async with client.stream("GET", "/api/live/stream?limit=1&interval=0.5") as resp:
+            assert resp.status_code == 200
+            assert "text/event-stream" in resp.headers["content-type"]
+
+
+@pytest.mark.asyncio
+async def test_stream_returns_valid_json_events(app):
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        async with client.stream("GET", "/api/live/stream?limit=2&interval=0.5") as resp:
+            events = []
+            async for line in resp.aiter_lines():
+                if line.startswith("data: "):
+                    payload = json.loads(line[6:])
+                    events.append(payload)
+
+            assert len(events) == 2
+
+
+@pytest.mark.asyncio
+async def test_event_has_required_fields(app):
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        async with client.stream("GET", "/api/live/stream?limit=1&interval=0.5") as resp:
+            async for line in resp.aiter_lines():
+                if line.startswith("data: "):
+                    event = json.loads(line[6:])
+                    required = {
+                        "event_id",
+                        "timestamp",
+                        "npi",
+                        "provider_name",
+                        "state",
+                        "city",
+                        "hcpcs_code",
+                        "submitted_charge",
+                        "risk_score",
+                        "legitimacy_score",
+                        "case_label",
+                        "signals",
+                        "scoring_latency_ms",
+                    }
+                    assert required.issubset(event.keys()), (
+                        f"Missing fields: {required - event.keys()}"
+                    )
+                    break
+
+
+@pytest.mark.asyncio
+async def test_event_scores_are_valid(app):
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        async with client.stream("GET", "/api/live/stream?limit=1&interval=0.5") as resp:
+            async for line in resp.aiter_lines():
+                if line.startswith("data: "):
+                    event = json.loads(line[6:])
+                    assert 0 <= event["risk_score"] <= 100
+                    assert 0 <= event["legitimacy_score"] <= 100
+                    assert event["case_label"] in ("high_risk", "review", "stable")
+                    assert event["scoring_latency_ms"] >= 0
+                    break
+
+
+@pytest.mark.asyncio
+async def test_limit_parameter_stops_stream(app):
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        async with client.stream("GET", "/api/live/stream?limit=3&interval=0.5") as resp:
+            count = 0
+            async for line in resp.aiter_lines():
+                if line.startswith("data: "):
+                    count += 1
+            assert count == 3


### PR DESCRIPTION
## Summary

- Add `GET /api/live/stream` SSE endpoint that samples random claims, scores them through the 14-signal scoring engine + Isolation Forest anomaly detector, and streams results with live latency measurement
- Configurable `interval` (0.5-5s) and `limit` (0=infinite) query parameters
- Registered as public route — SSE clients (browser `EventSource`) cannot send `Authorization` headers; production should gate via Istio JWT policy
- 5 async tests with mocked DB covering content-type, JSON validity, required fields, score ranges, and limit behavior

## Test plan

- [x] `ruff check` passes (lint)
- [x] `ruff format --check` passes (formatting)
- [x] `mypy` passes (type check)
- [x] `pytest tests/test_live.py -v` — 5/5 passing
- [ ] CI pipeline passes

Closes #313