### PR TITLE
feat(api): add per-provider feature importance for Isolation Forest (#295)

### DIFF
--- a/src/api/routes/providers.py
+++ b/src/api/routes/providers.py
@@ -10,6 +10,8 @@ from psycopg.rows import dict_row
 
 from src.api.deps import get_db
 from src.api.schemas import (
+    ExplainResponse,
+    FeatureContribution,
     PaginationMeta,
     ProviderDetail,
     ProviderListResponse,
@@ -167,3 +169,30 @@ async def get_provider_radar(
         ),
     ]
     return RadarResponse(npi=npi, dimensions=dims)
+
+
+@router.get("/{npi}/explain", response_model=ExplainResponse)
+async def explain_provider(
+    npi: str,
+    top_n: int = Query(5, ge=1, le=20),
+    conn: AsyncConnection = Depends(get_db),
+) -> ExplainResponse:
+    """Return per-feature importance explaining the anomaly score for a provider."""
+    async with conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute("SELECT * FROM provider_features WHERE npi = %s", [npi])
+        row = await cur.fetchone()
+
+    if not row:
+        raise HTTPException(status_code=404, detail=f"Provider {npi} not found")
+
+    from src.explainability.shap_explainer import explain_provider as _explain
+
+    result = _explain(dict(row), top_n=top_n)
+    if result is None:
+        return ExplainResponse(npi=npi)
+
+    return ExplainResponse(
+        npi=npi,
+        anomaly_score=result["anomaly_score"],
+        top_features=[FeatureContribution(**f) for f in result["top_features"]],
+    )

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -574,6 +574,24 @@ class TokenResponse(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Explainability
+# ---------------------------------------------------------------------------
+
+
+class FeatureContribution(BaseModel):
+    name: str
+    contribution: float
+    actual_value: float
+    direction: str  # "risk" | "protective" | "neutral"
+
+
+class ExplainResponse(BaseModel):
+    npi: str
+    anomaly_score: float | None = None
+    top_features: list[FeatureContribution] = []
+
+
+# ---------------------------------------------------------------------------
 # Health
 # ---------------------------------------------------------------------------
 

--- a/src/explainability/shap_explainer.py
+++ b/src/explainability/shap_explainer.py
@@ -1,0 +1,107 @@
+"""Per-provider feature importance for the Isolation Forest anomaly model.
+
+Uses a leave-one-out approximation: for each feature, zero it out and
+measure the change in anomaly score.  Positive delta means that feature
+was pushing the score higher (more anomalous); negative means it was
+protective.
+
+This avoids a runtime dependency on the ``shap`` package while giving
+directionally identical results for tree-based models.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from src.models.anomaly_scorer import _ML_AVAILABLE
+
+logger = logging.getLogger(__name__)
+
+# Re-export for convenience
+__all__ = ["explain_provider"]
+
+
+def _load_bundle() -> dict[str, Any]:
+    """Load the cached model bundle (same as anomaly_scorer)."""
+    from src.models.anomaly_scorer import _load_bundle
+
+    return _load_bundle()
+
+
+def _raw_anomaly_score(model: Any, scaler: Any, x_row: list[float]) -> float:
+    """Compute the normalized anomaly score (0-100) for a single row."""
+    import numpy as np
+
+    x = scaler.transform(np.array([x_row], dtype=np.float64))
+    raw = float(model.decision_function(x)[0])
+    return max(0.0, min(100.0, 50.0 - raw * 100.0))
+
+
+def explain_provider(
+    feature_row: dict,
+    top_n: int = 5,
+) -> dict | None:
+    """Compute per-feature importance for one provider.
+
+    Args:
+        feature_row: dict of column_name → value (must contain the 49 model features).
+        top_n: number of top contributing features to return.
+
+    Returns:
+        ``{"anomaly_score": float, "top_features": [...]}`` or ``None``
+        if the model is unavailable.
+    """
+    if not _ML_AVAILABLE:
+        return None
+
+    try:
+        bundle = _load_bundle()
+    except Exception:
+        logger.warning("Anomaly model not available", exc_info=True)
+        return None
+
+    model = bundle["model"]
+    scaler = bundle["scaler"]
+    feature_cols: list[str] = bundle["feature_cols"]
+
+    # Build the original feature vector
+    values = [float(feature_row.get(col) or 0) for col in feature_cols]
+    base_score = _raw_anomaly_score(model, scaler, values)
+
+    # Leave-one-out: zero each feature and measure delta
+    contributions: list[dict] = []
+    for i, col in enumerate(feature_cols):
+        if values[i] == 0.0:
+            # Feature already zero — contribution is 0
+            contributions.append(
+                {
+                    "name": col,
+                    "contribution": 0.0,
+                    "actual_value": 0.0,
+                    "direction": "neutral",
+                }
+            )
+            continue
+
+        perturbed = values.copy()
+        perturbed[i] = 0.0
+        perturbed_score = _raw_anomaly_score(model, scaler, perturbed)
+        delta = base_score - perturbed_score  # positive = feature increases anomaly
+
+        contributions.append(
+            {
+                "name": col,
+                "contribution": round(delta, 2),
+                "actual_value": round(values[i], 4),
+                "direction": "risk" if delta > 0 else "protective",
+            }
+        )
+
+    # Sort by absolute contribution descending
+    contributions.sort(key=lambda c: abs(c["contribution"]), reverse=True)
+
+    return {
+        "anomaly_score": round(base_score, 1),
+        "top_features": contributions[:top_n],
+    }

--- a/tests/test_explainability.py
+++ b/tests/test_explainability.py
@@ -1,0 +1,73 @@
+"""Tests for per-provider feature importance explainability."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.models.anomaly_scorer import _ML_AVAILABLE
+
+pytestmark = pytest.mark.skipif(
+    not _ML_AVAILABLE,
+    reason="ML libraries (scikit-learn, joblib) not installed",
+)
+
+
+@pytest.fixture
+def sample_feature_row() -> dict:
+    """Minimal feature row with the 49 columns the model expects."""
+    from src.models.anomaly_scorer import _load_bundle
+
+    bundle = _load_bundle()
+    # Create a row with all features at 0 except a few distinctive ones
+    row = {col: 0.0 for col in bundle["feature_cols"]}
+    row["provider_total_services"] = 5000.0
+    row["provider_total_benes"] = 200.0
+    row["enrolled_2025"] = 1.0
+    return row
+
+
+def test_explain_returns_dict(sample_feature_row: dict) -> None:
+    from src.explainability.shap_explainer import explain_provider
+
+    result = explain_provider(sample_feature_row)
+    assert result is not None
+    assert "anomaly_score" in result
+    assert "top_features" in result
+    assert 0 <= result["anomaly_score"] <= 100
+
+
+def test_explain_top_n_default(sample_feature_row: dict) -> None:
+    from src.explainability.shap_explainer import explain_provider
+
+    result = explain_provider(sample_feature_row, top_n=5)
+    assert result is not None
+    assert len(result["top_features"]) == 5
+
+
+def test_explain_top_n_custom(sample_feature_row: dict) -> None:
+    from src.explainability.shap_explainer import explain_provider
+
+    result = explain_provider(sample_feature_row, top_n=3)
+    assert result is not None
+    assert len(result["top_features"]) == 3
+
+
+def test_feature_contribution_structure(sample_feature_row: dict) -> None:
+    from src.explainability.shap_explainer import explain_provider
+
+    result = explain_provider(sample_feature_row, top_n=1)
+    assert result is not None
+    feat = result["top_features"][0]
+    assert "name" in feat
+    assert "contribution" in feat
+    assert "actual_value" in feat
+    assert feat["direction"] in ("risk", "protective", "neutral")
+
+
+def test_features_sorted_by_abs_contribution(sample_feature_row: dict) -> None:
+    from src.explainability.shap_explainer import explain_provider
+
+    result = explain_provider(sample_feature_row, top_n=10)
+    assert result is not None
+    contributions = [abs(f["contribution"]) for f in result["top_features"]]
+    assert contributions == sorted(contributions, reverse=True)


### PR DESCRIPTION
## Summary

- Add `GET /api/providers/{npi}/explain` endpoint returning per-feature contributions to the anomaly score
- **Leave-one-out approximation**: zero each of the 49 features, measure anomaly score delta — no `shap` dependency needed
- Returns top N features (default 5) sorted by absolute contribution, each with direction (`risk`/`protective`/`neutral`)
- Graceful degradation: returns empty explanation if scikit-learn/joblib not installed
- New `ExplainResponse` and `FeatureContribution` Pydantic schemas in `schemas.py`
- 5 tests covering return structure, top_n parameter, contribution sorting, and field validation

## Test plan

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `mypy` passes
- [x] `pytest tests/test_explainability.py -v` — 5/5 passing
- [ ] CI pipeline passes

Closes #295