### PR TITLE
docs: update docs for Live Monitor, SSE streaming, and ML explainability

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@
 | Phase 2: Scoring + API   | Mar 20 | **Done** | Scoring engine, all REST endpoints, peer baselines     |
 | Phase 3: AI Signals      | Mar 22 | **Done** | Text-to-SQL, risk narratives, anomaly detection        |
 | Phase 4: User Interface  | Mar 24 | **Done** | Claims simulator, investigation workflow, chat sidebar |
+| Phase 4b: Live Monitor   | Mar 24 | **Done** | SSE real-time payment monitor, ML explainability UI    |
 | Phase 5: Ship            | Mar 25 | **Done** | Demo script, AI/OSS disclosure, judge access           |
 
 **Demo Day**: March 27, 2026 — Reston, Virginia
@@ -78,7 +79,8 @@ CMS loses an estimated $60B+ annually to improper payments across Medicare and M
 2. **Transparent Decision Logic** — Rule-based scoring with peer comparison, validated against revocation outcomes
 3. **AI-Assisted Investigation** — LLM-powered natural language queries, risk narratives, and chat interface for analysts
 4. **Cloud-Native Architecture** — EKS, ArgoCD, Terraform — designed for scale
-5. **Mission-Ready** — Clear pathway from MVP to agency pilot
+5. **Real-Time Scoring** — SSE-streamed live payment monitor scores claims in under 50ms
+6. **Mission-Ready** — Clear pathway from MVP to agency pilot
 
 ## Architecture
 
@@ -135,17 +137,17 @@ All datasets are publicly available and currently downloadable. No PHI is used.
 
 ## Tech Stack
 
-| Layer    | Technology                                            | Status |
-| -------- | ----------------------------------------------------- | ------ |
-| Frontend | Vite + React 19 + TypeScript + Tailwind v4 + Recharts | Live   |
-| Backend  | Python 3.12 + FastAPI + psycopg                       | Live   |
-| Database | PostgreSQL 16 (EKS StatefulSet)                       | Live   |
-| Graph    | Neo4j 5 Community (EKS StatefulSet)                   | Live   |
-| Scoring  | Rule-based taxonomy (13 signals) + Isolation Forest   | Live   |
-| AI       | AWS Bedrock (Claude) — narratives, text-to-SQL, chat  | Live   |
-| ETL      | DuckDB + Polars                                       | Done   |
-| CI/CD    | GitHub Actions (unified pipeline) + ECR + ArgoCD      | Live   |
-| Infra    | AWS EKS + Istio + Terraform                           | Live   |
+| Layer    | Technology                                                                        | Status |
+| -------- | --------------------------------------------------------------------------------- | ------ |
+| Frontend | Vite + React 19 + TypeScript + Tailwind v4 + Recharts                             | Live   |
+| Backend  | Python 3.12 + FastAPI + psycopg                                                   | Live   |
+| Database | PostgreSQL 16 (EKS StatefulSet)                                                   | Live   |
+| Graph    | Neo4j 5 Community (EKS StatefulSet)                                               | Live   |
+| Scoring  | Rule-based taxonomy (14 signals) + Isolation Forest + per-provider explainability | Live   |
+| AI       | AWS Bedrock (Claude) — narratives, text-to-SQL, chat                              | Live   |
+| ETL      | DuckDB + Polars                                                                   | Done   |
+| CI/CD    | GitHub Actions (unified pipeline) + ECR + ArgoCD                                  | Live   |
+| Infra    | AWS EKS + Istio + Terraform                                                       | Live   |
 
 ## Quickstart
 

--- a/docs/architecture-v3.md
+++ b/docs/architecture-v3.md
@@ -36,9 +36,10 @@ This is a real application, not a demo script. It loads 19GB of public CMS data 
 a database, builds a provider evidence graph, harvests signals, and provides two
 interfaces:
 
-1. **Claims Simulator** — Payments flow in, get scanned, risk-scored in real time
-   with full transparency into every factor
-2. **Investigation Chat** — Sidebar where anyone (not just data engineers) can ask
+1. **Live Payment Monitor** — Claims stream in via SSE, scored in real time (<50ms),
+   displayed on a live US map with pulsing risk dots
+2. **Claims Simulator** — Select a claim, push through scoring engine, see full signal breakdown
+3. **Investigation Chat** — Sidebar where anyone (not just data engineers) can ask
    plain English questions and get answers with charts
 
 ## System Architecture
@@ -75,6 +76,8 @@ interfaces:
 │  GET  /api/peers/{npi}     — Peer group comparison data                  │
 │  GET  /api/fairness        — Flagging rate by geography + specialty       │
 │  GET  /api/graph/{npi}     — Evidence graph nodes + edges from Neo4j      │
+│  GET  /api/live/stream     — SSE real-time scored claim stream            │
+│  GET  /api/providers/{npi}/explain — Per-provider ML feature importance  │
 │  GET  /api/health          — Health check for k8s probes                 │
 ├──────────┬──────────┬──────────────────┬────────────────────────────────┤
 │  Signal  │    AI    │  Scoring Engine  │  Data Access Layer             │

--- a/docs/model-card-isolation-forest.md
+++ b/docs/model-card-isolation-forest.md
@@ -96,6 +96,22 @@ normalized = clamp(50 - raw_score * 100, 0, 100)
 
 Higher scores indicate more anomalous billing patterns. Scores are ordinal rankings, not calibrated probabilities. The score is served via `src/models/anomaly_scorer.py` using lazy-loaded model caching (`lru_cache`).
 
+## Per-Provider Feature Importance
+
+The system provides per-provider explainability via a **leave-one-out approximation** (`src/explainability/shap_explainer.py`, exposed at `GET /api/providers/{npi}/explain`).
+
+**Method**: For each of the 49 features, zero the value, re-score through the model, and measure the anomaly score delta. Features with the largest absolute delta are the strongest contributors to that provider's anomaly score.
+
+| Delta    | Direction  | Meaning                                      |
+| -------- | ---------- | -------------------------------------------- |
+| Positive | Risk       | Feature was pushing anomaly score higher     |
+| Negative | Protective | Feature was reducing the anomaly score       |
+| Zero     | Neutral    | Feature was already at zero or had no effect |
+
+**Trade-offs vs. SHAP**: Leave-one-out uses zero as the baseline rather than the expected value, which may overstate the contribution of binary features (e.g., `enrolled_2025`). However, it requires no additional dependencies, runs in under 100ms, and produces directionally identical top-feature rankings for tree-based models.
+
+**UI integration**: The Provider Detail page displays the top 5 features as horizontal bars (red = risk-increasing, green = protective) alongside a Score Agreement indicator comparing the rule-based risk score and the ML anomaly score.
+
 ## Limitations
 
 1. **Single-year cross-section**: Trained on 2022 data only. No temporal validation across years. Provider behavior may shift over time.
@@ -126,3 +142,4 @@ Higher scores indicate more anomalous billing patterns. Scores are ordinal ranki
 | Version | Date       | Notes                                                         |
 | ------- | ---------- | ------------------------------------------------------------- |
 | 1.0.0   | March 2026 | Initial model (200 estimators, 49 features, 10,282 providers) |
+| 1.1.0   | March 2026 | Added per-provider leave-one-out feature importance endpoint  |

--- a/docs/risk-scoring-methodology.md
+++ b/docs/risk-scoring-methodology.md
@@ -132,3 +132,32 @@ Every scored case carries:
 - The peer baseline value for context
 
 This enables reviewers to understand exactly why a provider was flagged and trace every point back to a specific data source and comparison methodology.
+
+## ML Anomaly Score & Feature Importance
+
+In addition to the rule-based scoring engine, each provider receives an independent **anomaly score** from an Isolation Forest model (see [model-card-isolation-forest.md](model-card-isolation-forest.md)). The anomaly score (0-100) captures statistically unusual billing patterns that may not trigger explicit threshold-based rules.
+
+### Per-Provider Feature Importance
+
+The system provides per-provider feature importance via a **leave-one-out approximation** (`GET /api/providers/{npi}/explain`). For each of the 49 model features:
+
+1. Zero the feature value
+2. Re-score through the Isolation Forest
+3. Measure the delta from the baseline anomaly score
+
+Positive delta = the feature was pushing the score higher (risk-increasing). Negative delta = the feature was protective. The top contributing features are returned ranked by absolute contribution.
+
+This approach avoids a runtime dependency on SHAP while giving directionally identical results for tree-based models in under 100ms.
+
+### Score Agreement Indicator
+
+The Provider Detail page displays a **Score Agreement** indicator comparing the rule-based risk score and the ML anomaly score:
+
+| Agreement    | Condition                                | Meaning                                   |
+| ------------ | ---------------------------------------- | ----------------------------------------- |
+| Corroborated | Both scores >= 51                        | Independent signals agree on high risk    |
+| Divergent    | One >= 51, the other < 51                | Signals disagree — warrants investigation |
+| Consistent   | Both scores < 31                         | Both signals agree on low risk            |
+| Mixed        | Both in the 31-50 range, or one moderate | Moderate range — routine review           |
+
+This dual-signal design adds investigative depth: corroborated cases are highest priority, while divergent cases surface patterns that one method alone would miss.


### PR DESCRIPTION
## Summary

Updates four key documentation files to reflect the features added in PRs #337-#341:

- **README.md**: Added Phase 4b (Live Monitor + ML explainability), updated scoring tech stack to "14 signals + per-provider explainability", added real-time scoring as Key Principle #5
- **Architecture v3**: Added `GET /api/live/stream` and `GET /api/providers/{npi}/explain` to API layer listing, added Live Payment Monitor as the first interface
- **Risk Scoring Methodology**: New section on ML Anomaly Score with leave-one-out feature importance method and Score Agreement indicator table (Corroborated / Divergent / Consistent / Mixed)
- **Model Card**: New Per-Provider Feature Importance section documenting the leave-one-out method, trade-offs vs SHAP, UI integration, and version history entry (1.1.0)

## Test plan

- [ ] Docs render correctly on GitHub (markdown tables, links)
- [ ] No broken internal links between docs