### PR TITLE
fix(ci): propagate always() through Build → Scan → Release → Deploy chain

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -300,6 +300,7 @@ jobs:
     name: Scan
     runs-on: ubuntu-latest
     needs: [build]
+    if: always() && needs.build.result == 'success'
     steps:
       - name: Download API image
         uses: actions/download-artifact@v4
@@ -349,7 +350,11 @@ jobs:
   release:
     name: Release
     needs: [scan]
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: |
+      always() &&
+      needs.scan.result == 'success' &&
+      github.ref == 'refs/heads/main' &&
+      github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -385,7 +390,11 @@ jobs:
   deploy:
     name: Deploy
     needs: [release]
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: |
+      always() &&
+      needs.release.result == 'success' &&
+      github.ref == 'refs/heads/main' &&
+      github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

Follow-up to #344. The `always()` + explicit result check is needed on **every** job in the deploy chain, not just Build. When Build uses `always()`, its downstream jobs (Scan, Release, Deploy) with default `success()` also skip.

Adds `if: always() && needs.*.result == 'success'` to Scan, Release, and Deploy (Release and Deploy also retain the `refs/heads/main` push guard).

## Test plan

- [ ] Full chain runs: Build → Scan → Release → Deploy
- [ ] Images pushed to ECR with SHA + latest tags
- [ ] EKS rollout completes
- [ ] Site live at argus.precise-lab.com with Live Monitor