### PR TITLE
chore(ci): address pipeline warnings — Node.js 24, Docker, lint (#351)

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -20,6 +20,7 @@ concurrency:
 
 env:
   ECR_REGISTRY: ${{ vars.AWS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 permissions:
   contents: read
@@ -156,7 +157,7 @@ jobs:
 
       - name: Test
         env:
-          JWT_SECRET_KEY: test-secret-for-ci-only
+          JWT_SECRET_KEY: test-secret-for-ci-only-must-be-32-bytes!
         run: pytest --cov=src --cov-branch --cov-report=xml --cov-report=html --cov-report=term-missing -q
 
       - name: Coverage threshold check

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.12-slim AS builder
 WORKDIR /app
 
 COPY pyproject.toml .
-RUN pip install --no-cache-dir --prefix=/install .
+RUN pip install --no-cache-dir --root-user-action=ignore --prefix=/install .
 
 COPY src/ src/
 

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -57,6 +57,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   );
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export function useAuth() {
   const ctx = useContext(AuthContext);
   if (!ctx) throw new Error("useAuth must be used within AuthProvider");


### PR DESCRIPTION
## Summary
- **P1**: Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` env — eliminates Node.js 20 deprecation warnings in all 7 jobs
- **P2**: Add `--root-user-action=ignore` to pip in Dockerfile — suppresses root user warning
- **P3**: Use 32-byte JWT secret in CI (fixes HMAC warning); suppress `react-refresh/only-export-components` in AuthContext.tsx
- **P4**: Acknowledged — upstream SBOM/Trivy notices, no action needed

Closes #351

## Test plan
- [ ] CI pipeline runs with 0 Node.js 20 deprecation warnings
- [ ] Docker build step shows no pip root-user warning
- [ ] Backend tests show 0 pytest warnings
- [ ] Frontend lint shows 0 eslint warnings