### PR TITLE
fix(ci): preserve exit code in SBOM generation (#368)

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -292,7 +292,7 @@ jobs:
         run: cd frontend && npm ci
 
       - name: Generate frontend SBOM
-        run: cd frontend && npx @cyclonedx/cyclonedx-npm --ignore-npm-errors --output-file ../sbom-frontend.cdx.json 2>&1 | grep -v "^npm warn"
+        run: cd frontend && npx @cyclonedx/cyclonedx-npm --ignore-npm-errors --output-file ../sbom-frontend.cdx.json 2> >(grep -v "^npm warn" >&2)
 
       - name: Upload SBOMs
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Fix SBOM generation pipe that masked non-zero exit codes.

**Before:** `2>&1 | grep -v "^npm warn"` — if `npx cyclonedx-npm` fails, `grep` exits 0, hiding the error.

**After:** `2> >(grep -v "^npm warn" >&2)` — filters stderr warnings via process substitution while preserving the exit code from `npx`.

## Test plan
- [ ] CI passes
- [ ] SBOM step still filters npm warn lines
- [ ] npx exit code is preserved (not masked by grep)

Closes #368