### PR TITLE
fix(frontend): lock risk map, link state rows, improve evidence graph (#354)

### DIFF
--- a/frontend/src/components/EvidenceGraph.tsx
+++ b/frontend/src/components/EvidenceGraph.tsx
@@ -17,58 +17,127 @@ export function EvidenceGraph({ nodes, edges }: { nodes: GraphNode[]; edges: Gra
     );
   }
 
-  const width = 500;
-  const height = 300;
+  const width = 720;
+  const height = 360;
   const cx = width / 2;
   const cy = height / 2;
-  const radius = Math.min(width, height) / 2 - 40;
 
-  const positions = nodes.map((_, i) => {
-    const angle = (2 * Math.PI * i) / nodes.length - Math.PI / 2;
-    return { x: cx + radius * Math.cos(angle), y: cy + radius * Math.sin(angle) };
+  const providerIndex = Math.max(
+    nodes.findIndex((node) => node.type === 'provider'),
+    0,
+  );
+  const providerNode = nodes[providerIndex];
+  const outerNodes = nodes.filter((_, index) => index !== providerIndex);
+  const outerRadius = Math.min(width, height) / 2 - 64;
+
+  const positions = new Map<string, { x: number; y: number }>();
+  positions.set(providerNode.id, { x: cx, y: cy });
+
+  outerNodes.forEach((node, index) => {
+    const angle = (2 * Math.PI * index) / Math.max(outerNodes.length, 1) - Math.PI / 2;
+    positions.set(node.id, {
+      x: cx + outerRadius * Math.cos(angle),
+      y: cy + outerRadius * Math.sin(angle),
+    });
   });
 
-  const nodeMap = new Map(nodes.map((n, i) => [n.id, i]));
+  const wrapLabel = (label: string) => {
+    const words = label.split(/\s+/);
+    const lines: string[] = [];
+    let current = '';
+
+    for (const word of words) {
+      const candidate = current ? `${current} ${word}` : word;
+      if (candidate.length <= 16) {
+        current = candidate;
+      } else {
+        if (current) {
+          lines.push(current);
+        }
+        current = word;
+      }
+    }
+
+    if (current) {
+      lines.push(current);
+    }
+
+    if (!lines.length) {
+      return [label.length > 16 ? `${label.slice(0, 14)}…` : label];
+    }
+
+    return lines.slice(0, 2).map((line, index, array) => {
+      if (index === array.length - 1 && line.length > 16) {
+        return `${line.slice(0, 14)}…`;
+      }
+      return line;
+    });
+  };
 
   return (
-    <svg viewBox={`0 0 ${width} ${height}`} className="w-full h-auto">
+    <svg viewBox={`0 0 ${width} ${height}`} className="w-full h-auto min-h-[320px]">
       {edges.map((edge, i) => {
-        const si = nodeMap.get(edge.source);
-        const ti = nodeMap.get(edge.target);
-        if (si === undefined || ti === undefined) return null;
+        const source = positions.get(edge.source);
+        const target = positions.get(edge.target);
+        if (!source || !target) return null;
         return (
           <line
             key={i}
-            x1={positions[si].x}
-            y1={positions[si].y}
-            x2={positions[ti].x}
-            y2={positions[ti].y}
+            x1={source.x}
+            y1={source.y}
+            x2={target.x}
+            y2={target.y}
             stroke="#cbd5e1"
+            strokeOpacity={0.85}
             strokeWidth={1.5}
           />
         );
       })}
-      {nodes.map((node, i) => (
+      {nodes.map((node) => {
+        const position = positions.get(node.id);
+        if (!position) {
+          return null;
+        }
+
+        const labelLines = wrapLabel(node.label);
+        const isProvider = node.id === providerNode.id;
+
+        return (
         <g key={node.id}>
+          <title>{node.label}</title>
           <circle
-            cx={positions[i].x}
-            cy={positions[i].y}
-            r={12}
+            cx={position.x}
+            cy={position.y}
+            r={isProvider ? 16 : 12}
             fill={TYPE_COLORS[node.type] ?? '#94a3b8'}
-            opacity={0.85}
+            opacity={0.9}
           />
-          <text
-            x={positions[i].x}
-            y={positions[i].y + 22}
-            textAnchor="middle"
-            fontSize={9}
-            fontWeight={600}
-            fill="#475569"
-          >
-            {node.label.length > 18 ? node.label.slice(0, 16) + '…' : node.label}
-          </text>
+          <rect
+            x={position.x - 46}
+            y={position.y + (isProvider ? 22 : 20)}
+            width={92}
+            height={labelLines.length > 1 ? 26 : 16}
+            rx={6}
+            fill="white"
+            fillOpacity={0.92}
+            stroke="#e2e8f0"
+          />
+          {labelLines.map((line, index) => (
+            <text
+              key={`${node.id}-${index}`}
+              x={position.x}
+              y={position.y + (isProvider ? 33 : 31) + index * 10}
+              textAnchor="middle"
+              fontSize={9}
+              fontWeight={600}
+              fill="#475569"
+            >
+              {line}
+            </text>
+          ))}
         </g>
-      ))}
+        );
+      })}
     </svg>
   );
 }

--- a/frontend/src/pages/RiskMap.tsx
+++ b/frontend/src/pages/RiskMap.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { TrendingUp, Map } from 'lucide-react';
-import { ComposableMap, Geographies, Geography, ZoomableGroup } from 'react-simple-maps';
+import { Link } from 'react-router-dom';
+import { ComposableMap, Geographies, Geography } from 'react-simple-maps';
 import { getHeatmap } from '../lib/api';
 import type { HeatmapEntry } from '../lib/api';
 import { cn } from '../lib/utils';
@@ -87,42 +88,40 @@ export function RiskMap() {
               height={500}
               style={{ width: '100%', height: 'auto' }}
             >
-              <ZoomableGroup>
-                <Geographies geography={GEO_URL}>
-                  {({ geographies }) =>
-                    geographies.map((geo) => {
-                      const fips = geo.id as string;
-                      const abbr = FIPS_TO_ABBR[fips];
-                      const entry = abbr ? byState.get(abbr) : undefined;
-                      return (
-                        <Geography
-                          key={geo.rsmKey}
-                          geography={geo}
-                          fill={fillForRisk(entry?.avg_risk_score)}
-                          stroke="#fff"
-                          strokeWidth={0.5}
-                          style={{
-                            default: { outline: 'none' },
-                            hover: { outline: 'none', filter: 'brightness(0.92)', cursor: 'pointer' },
-                            pressed: { outline: 'none' },
-                          }}
-                          onMouseEnter={(evt) => {
-                            if (entry) {
-                              setTooltip({ entry, x: evt.clientX, y: evt.clientY });
-                            }
-                          }}
-                          onMouseMove={(evt) => {
-                            if (entry) {
-                              setTooltip({ entry, x: evt.clientX, y: evt.clientY });
-                            }
-                          }}
-                          onMouseLeave={() => setTooltip(null)}
-                        />
-                      );
-                    })
-                  }
-                </Geographies>
-              </ZoomableGroup>
+              <Geographies geography={GEO_URL}>
+                {({ geographies }) =>
+                  geographies.map((geo) => {
+                    const fips = geo.id as string;
+                    const abbr = FIPS_TO_ABBR[fips];
+                    const entry = abbr ? byState.get(abbr) : undefined;
+                    return (
+                      <Geography
+                        key={geo.rsmKey}
+                        geography={geo}
+                        fill={fillForRisk(entry?.avg_risk_score)}
+                        stroke="#fff"
+                        strokeWidth={0.5}
+                        style={{
+                          default: { outline: 'none' },
+                          hover: { outline: 'none', filter: 'brightness(0.96)', cursor: 'default' },
+                          pressed: { outline: 'none' },
+                        }}
+                        onMouseEnter={(evt) => {
+                          if (entry) {
+                            setTooltip({ entry, x: evt.clientX, y: evt.clientY });
+                          }
+                        }}
+                        onMouseMove={(evt) => {
+                          if (entry) {
+                            setTooltip({ entry, x: evt.clientX, y: evt.clientY });
+                          }
+                        }}
+                        onMouseLeave={() => setTooltip(null)}
+                      />
+                    );
+                  })
+                }
+              </Geographies>
             </ComposableMap>
 
             {/* Floating Tooltip */}
@@ -155,7 +154,11 @@ export function RiskMap() {
             <h3 className="font-bold text-slate-800 flex items-center gap-2 mb-4"><TrendingUp className="w-4 h-4 text-rose-500" /> Highest Risk States</h3>
             <div className="space-y-2 max-h-[500px] overflow-y-auto">
               {sortedByRisk.slice(0, 20).map((entry, i) => (
-                <div key={entry.state} className="flex items-center justify-between py-2 px-3 rounded-lg hover:bg-slate-50 transition-colors">
+                <Link
+                  key={entry.state}
+                  to={`/providers?state=${encodeURIComponent(entry.state)}`}
+                  className="flex items-center justify-between py-2 px-3 rounded-lg hover:bg-slate-50 transition-colors"
+                >
                   <div className="flex items-center gap-3">
                     <span className="text-[10px] font-black text-slate-400 w-5">{i + 1}.</span>
                     <span className="text-sm font-bold text-slate-800">{entry.state}</span>
@@ -165,7 +168,7 @@ export function RiskMap() {
                     <span className="text-xs text-slate-500">{entry.flagged_count} flagged</span>
                     <span className={cn('text-sm font-bold', scoreColor(entry.avg_risk_score))}>{entry.avg_risk_score.toFixed(1)}</span>
                   </div>
-                </div>
+                </Link>
               ))}
             </div>
           </div>

--- a/frontend/src/pages/__tests__/RiskMap.test.tsx
+++ b/frontend/src/pages/__tests__/RiskMap.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { RiskMap } from "../RiskMap";
+import { getHeatmap } from "../../lib/api";
+
+vi.mock("../../contexts/AuthContext", () => ({
+  useAuth: () => ({
+    user: {
+      id: 1,
+      username: "analyst",
+      role: "analyst",
+      full_name: "Test Analyst",
+    },
+    isAuthenticated: true,
+    isLoading: false,
+    login: vi.fn(),
+    logout: vi.fn(),
+  }),
+}));
+
+vi.mock("../../lib/api", () => ({
+  getHeatmap: vi.fn(),
+}));
+
+vi.mock("react-simple-maps", () => ({
+  ComposableMap: ({ children }: { children: React.ReactNode }) => <div data-testid="map">{children}</div>,
+  Geographies: ({ children }: { children: (props: { geographies: Array<{ id: string; rsmKey: string }> }) => React.ReactNode }) =>
+    <div>{children({ geographies: [{ id: "12", rsmKey: "FL" }, { id: "48", rsmKey: "TX" }] })}</div>,
+  Geography: ({ geography, onMouseEnter, onMouseLeave }: { geography: { id: string }; onMouseEnter?: (event: MouseEvent) => void; onMouseLeave?: () => void }) => (
+    <button
+      type="button"
+      data-testid={`state-${geography.id}`}
+      onMouseEnter={() => onMouseEnter?.({ clientX: 10, clientY: 10 } as MouseEvent)}
+      onMouseLeave={onMouseLeave}
+    >
+      {geography.id}
+    </button>
+  ),
+}));
+
+const mockHeatmap = {
+  data: [
+    { state: "FL", provider_count: 10, avg_risk_score: 24.3, flagged_count: 2 },
+    { state: "TX", provider_count: 8, avg_risk_score: 18.1, flagged_count: 1 },
+  ],
+};
+
+function renderRiskMap() {
+  return render(
+    <MemoryRouter initialEntries={["/risk-map"]}>
+      <Routes>
+        <Route path="/risk-map" element={<RiskMap />} />
+        <Route path="/providers" element={<div data-testid="providers-page">Providers page</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("RiskMap", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getHeatmap).mockResolvedValue(mockHeatmap);
+  });
+
+  it("renders state rankings from heatmap data", async () => {
+    renderRiskMap();
+
+    await waitFor(() => {
+      expect(screen.getByText("FL")).toBeInTheDocument();
+    });
+    expect(screen.getByText("TX")).toBeInTheDocument();
+  });
+
+  it("links a state row to the providers page with the state query", async () => {
+    const user = userEvent.setup();
+    renderRiskMap();
+
+    const floridaLabel = await screen.findByText("FL");
+    const floridaLink = floridaLabel.closest("a");
+    expect(floridaLink).not.toBeNull();
+    expect(floridaLink).toHaveAttribute("href", "/providers?state=FL");
+
+    await user.click(floridaLink!);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("providers-page")).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #354
Closes #355
Closes #356
Closes #357

Three frontend-only UI fixes for the risk map page and provider evidence graph.

### Changes

**fix(#355) — Lock choropleth interactions**
- Removed `ZoomableGroup` from `RiskMap.tsx`; the map is now static (no drag or zoom)
- Hover tooltip and colour fill are preserved; cursor set to `default` on hover

**fix(#356) — State rows link to filtered providers**
- Each state ranking row is now a `<Link>` to `/providers?state=<ABBR>`
- `Providers.tsx` already initialises the state filter from URL search params, so the link lands with the state pre-selected

**fix(#357) — Evidence graph layout**
- SVG viewport enlarged to 720×360
- Provider node is pinned to the centre; all other nodes orbit on a radial ring (`outerRadius = 116px`)
- Two-line label wrapping with background `<rect>` chips and SVG `<title>` tooltips

### Tests

- Added `frontend/src/pages/__tests__/RiskMap.test.tsx`
  - Verifies state rankings render from heatmap data
  - Verifies each state row is an `<a>` pointing to `/providers?state=XX` and navigates on click
- Full Vitest suite: **178 / 178 passing**
- ESLint and `tsc --noEmit`: clean