### PR TITLE
fix(frontend): batch UI fixes — labels, map dots, navigation, case IDs

### DIFF
--- a/frontend/src/lib/helpers.ts
+++ b/frontend/src/lib/helpers.ts
@@ -1,56 +1,104 @@
-import type { RiskBand } from './api';
+import type { RiskBand } from "./api";
 
 export function riskBandLabel(band: RiskBand | null | undefined): string {
-  if (!band) return 'Unknown';
+  if (!band) return "Unknown";
   switch (band) {
-    case 'high_risk': return 'High Risk';
-    case 'review': return 'Review';
-    case 'stable': return 'Stable';
-    default: return band;
+    case "high_risk":
+      return "High Risk";
+    case "review":
+      return "Review";
+    case "stable":
+      return "Stable";
+    default:
+      return band;
   }
 }
 
 export function riskBandColor(band: RiskBand | null | undefined) {
   switch (band) {
-    case 'high_risk': return { bg: 'bg-rose-100', text: 'text-rose-700', border: 'border-rose-200' };
-    case 'review': return { bg: 'bg-amber-100', text: 'text-amber-700', border: 'border-amber-200' };
-    case 'stable': return { bg: 'bg-emerald-100', text: 'text-emerald-700', border: 'border-emerald-200' };
-    default: return { bg: 'bg-slate-100', text: 'text-slate-600', border: 'border-slate-200' };
+    case "high_risk":
+      return {
+        bg: "bg-rose-100",
+        text: "text-rose-700",
+        border: "border-rose-200",
+      };
+    case "review":
+      return {
+        bg: "bg-amber-100",
+        text: "text-amber-700",
+        border: "border-amber-200",
+      };
+    case "stable":
+      return {
+        bg: "bg-emerald-100",
+        text: "text-emerald-700",
+        border: "border-emerald-200",
+      };
+    default:
+      return {
+        bg: "bg-slate-100",
+        text: "text-slate-600",
+        border: "border-slate-200",
+      };
   }
 }
 
 export function scoreColor(score: number | null | undefined): string {
-  if (score == null) return 'text-slate-500';
-  if (score >= 51) return 'text-rose-600';
-  if (score >= 31) return 'text-amber-600';
-  return 'text-emerald-600';
+  if (score == null) return "text-slate-500";
+  if (score >= 51) return "text-rose-600";
+  if (score >= 31) return "text-amber-600";
+  return "text-emerald-600";
 }
 
 export function caseLabelColor(label: string | null | undefined) {
-  if (!label) return { bg: 'bg-slate-100', text: 'text-slate-600' };
+  if (!label) return { bg: "bg-slate-100", text: "text-slate-600" };
   const l = label.toLowerCase();
-  if (l.includes('high') || l.includes('critical')) return { bg: 'bg-rose-100', text: 'text-rose-700' };
-  if (l.includes('review') || l.includes('medium')) return { bg: 'bg-amber-100', text: 'text-amber-700' };
-  return { bg: 'bg-emerald-100', text: 'text-emerald-700' };
+  if (l.includes("high") || l.includes("critical"))
+    return { bg: "bg-rose-100", text: "text-rose-700" };
+  if (l.includes("review") || l.includes("medium"))
+    return { bg: "bg-amber-100", text: "text-amber-700" };
+  return { bg: "bg-emerald-100", text: "text-emerald-700" };
 }
 
 export function formatUSD(n: number | null | undefined): string {
-  if (n == null) return '—';
-  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(n);
+  if (n == null) return "—";
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  }).format(n);
 }
 
 export function formatCompactUSD(n: number | null | undefined): string {
-  if (n == null) return '—';
-  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', notation: 'compact', maximumFractionDigits: 1 }).format(n);
+  if (n == null) return "—";
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(n);
 }
 
 export function formatNumber(n: number | null | undefined): string {
-  if (n == null) return '—';
-  return new Intl.NumberFormat('en-US').format(n);
+  if (n == null) return "—";
+  return new Intl.NumberFormat("en-US").format(n);
 }
 
-export function providerDisplayName(p: { provider_name?: string | null; provider_last_org_name?: string | null; provider_first_name?: string | null; npi?: string }): string {
+export function formatCaseId(caseId: string): string {
+  const parts = caseId.split("|");
+  if (parts.length >= 2) return `${parts[0]} — ${parts[1]}`;
+  return caseId;
+}
+
+export function providerDisplayName(p: {
+  provider_name?: string | null;
+  provider_last_org_name?: string | null;
+  provider_first_name?: string | null;
+  npi?: string;
+}): string {
   if (p.provider_name) return p.provider_name;
-  const parts = [p.provider_last_org_name, p.provider_first_name].filter(Boolean);
-  return parts.length ? parts.join(', ') : p.npi ?? 'Unknown';
+  const parts = [p.provider_last_org_name, p.provider_first_name].filter(
+    Boolean,
+  );
+  return parts.length ? parts.join(", ") : (p.npi ?? "Unknown");
 }

--- a/frontend/src/pages/Claims.tsx
+++ b/frontend/src/pages/Claims.tsx
@@ -1,24 +1,39 @@
-import React from 'react';
-import { Search, ChevronLeft, ChevronRight, ExternalLink, FileText } from 'lucide-react';
-import { Link } from 'react-router-dom';
-import { getClaims } from '../lib/api';
-import type { Claim, PaginationMeta } from '../lib/api';
-import { cn } from '../lib/utils';
-import { formatUSD, scoreColor } from '../lib/helpers';
+import React from "react";
+import {
+  Search,
+  ChevronLeft,
+  ChevronRight,
+  ExternalLink,
+  FileText,
+} from "lucide-react";
+import { Link } from "react-router-dom";
+import { getClaims } from "../lib/api";
+import type { Claim, PaginationMeta, RiskBand } from "../lib/api";
+import { StatusBadge } from "../components/StatusBadge";
+import { cn } from "../lib/utils";
+import { formatUSD, scoreColor, formatCaseId } from "../lib/helpers";
 
 export function Claims() {
   const [claims, setClaims] = React.useState<Claim[]>([]);
-  const [meta, setMeta] = React.useState<PaginationMeta>({ page: 1, per_page: 25, total: 0, pages: 0 });
+  const [meta, setMeta] = React.useState<PaginationMeta>({
+    page: 1,
+    per_page: 25,
+    total: 0,
+    pages: 0,
+  });
   const [page, setPage] = React.useState(1);
-  const [search, setSearch] = React.useState('');
-  const [label, setLabel] = React.useState('');
-  const [riskMin, setRiskMin] = React.useState('');
+  const [search, setSearch] = React.useState("");
+  const [label, setLabel] = React.useState("");
+  const [riskMin, setRiskMin] = React.useState("");
   const [loading, setLoading] = React.useState(true);
 
   const fetchClaims = React.useCallback(async () => {
     setLoading(true);
     try {
-      const params: Record<string, string> = { page: String(page), per_page: '25' };
+      const params: Record<string, string> = {
+        page: String(page),
+        per_page: "25",
+      };
       if (search) params.npi = search;
       if (label) params.case_label = label;
       if (riskMin) params.risk_min = riskMin;
@@ -32,14 +47,18 @@ export function Claims() {
     }
   }, [page, search, label, riskMin]);
 
-  React.useEffect(() => { fetchClaims(); }, [fetchClaims]);
+  React.useEffect(() => {
+    fetchClaims();
+  }, [fetchClaims]);
 
   return (
     <div className="space-y-6 animate-in fade-in duration-500">
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
         <div>
           <h1 className="text-2xl font-bold text-slate-900">Claims</h1>
-          <p className="mt-1 text-sm text-slate-500">Browse service-level claim records with risk annotations.</p>
+          <p className="mt-1 text-sm text-slate-500">
+            Browse service-level claim records with risk annotations.
+          </p>
         </div>
         <div className="flex items-center gap-2 text-xs text-slate-500 font-medium bg-slate-100 px-3 py-1.5 rounded-lg">
           <FileText className="w-3.5 h-3.5" />
@@ -52,15 +71,40 @@ export function Claims() {
         <div className="flex flex-col md:flex-row gap-4">
           <div className="relative flex-1">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
-            <input type="text" placeholder="Search by NPI..." value={search} onChange={(e) => { setSearch(e.target.value); setPage(1); }} className="w-full pl-10 pr-4 py-2.5 text-sm rounded-xl border border-slate-200 bg-slate-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-300 transition-all" />
+            <input
+              type="text"
+              placeholder="Search by NPI..."
+              value={search}
+              onChange={(e) => {
+                setSearch(e.target.value);
+                setPage(1);
+              }}
+              className="w-full pl-10 pr-4 py-2.5 text-sm rounded-xl border border-slate-200 bg-slate-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-300 transition-all"
+            />
           </div>
-          <select value={label} onChange={(e) => { setLabel(e.target.value); setPage(1); }} className="min-w-[180px] px-4 py-2.5 text-sm rounded-xl border border-slate-200 bg-slate-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition-all">
+          <select
+            value={label}
+            onChange={(e) => {
+              setLabel(e.target.value);
+              setPage(1);
+            }}
+            className="min-w-[180px] px-4 py-2.5 text-sm rounded-xl border border-slate-200 bg-slate-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition-all"
+          >
             <option value="">All Labels</option>
             <option value="high_risk">High Risk</option>
             <option value="review">Review</option>
             <option value="stable">Stable</option>
           </select>
-          <input type="number" placeholder="Min score" value={riskMin} onChange={(e) => { setRiskMin(e.target.value); setPage(1); }} className="w-32 px-4 py-2.5 text-sm rounded-xl border border-slate-200 bg-slate-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition-all" />
+          <input
+            type="number"
+            placeholder="Min score"
+            value={riskMin}
+            onChange={(e) => {
+              setRiskMin(e.target.value);
+              setPage(1);
+            }}
+            className="w-32 px-4 py-2.5 text-sm rounded-xl border border-slate-200 bg-slate-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition-all"
+          />
         </div>
       </div>
 
@@ -70,57 +114,134 @@ export function Claims() {
           <table className="min-w-full divide-y divide-slate-200">
             <thead className="bg-slate-50/80">
               <tr>
-                <th className="px-5 py-3.5 text-left text-[10px] font-bold text-slate-500 uppercase tracking-widest">Case ID</th>
-                <th className="px-5 py-3.5 text-left text-[10px] font-bold text-slate-500 uppercase tracking-widest">NPI</th>
-                <th className="px-5 py-3.5 text-left text-[10px] font-bold text-slate-500 uppercase tracking-widest">HCPCS</th>
-                <th className="px-5 py-3.5 text-right text-[10px] font-bold text-slate-500 uppercase tracking-widest">Services</th>
-                <th className="px-5 py-3.5 text-right text-[10px] font-bold text-slate-500 uppercase tracking-widest">Benes</th>
-                <th className="px-5 py-3.5 text-right text-[10px] font-bold text-slate-500 uppercase tracking-widest">Charges</th>
-                <th className="px-5 py-3.5 text-right text-[10px] font-bold text-slate-500 uppercase tracking-widest">Risk</th>
-                <th className="px-5 py-3.5 text-left text-[10px] font-bold text-slate-500 uppercase tracking-widest">Label</th>
+                <th className="px-5 py-3.5 text-left text-[10px] font-bold text-slate-500 uppercase tracking-widest">
+                  Case ID
+                </th>
+                <th className="px-5 py-3.5 text-left text-[10px] font-bold text-slate-500 uppercase tracking-widest">
+                  NPI
+                </th>
+                <th className="px-5 py-3.5 text-left text-[10px] font-bold text-slate-500 uppercase tracking-widest">
+                  HCPCS
+                </th>
+                <th className="px-5 py-3.5 text-right text-[10px] font-bold text-slate-500 uppercase tracking-widest">
+                  Services
+                </th>
+                <th className="px-5 py-3.5 text-right text-[10px] font-bold text-slate-500 uppercase tracking-widest">
+                  Benes
+                </th>
+                <th className="px-5 py-3.5 text-right text-[10px] font-bold text-slate-500 uppercase tracking-widest">
+                  Charges
+                </th>
+                <th className="px-5 py-3.5 text-right text-[10px] font-bold text-slate-500 uppercase tracking-widest">
+                  Risk
+                </th>
+                <th className="px-5 py-3.5 text-left text-[10px] font-bold text-slate-500 uppercase tracking-widest">
+                  Label
+                </th>
                 <th className="px-5 py-3.5 text-left text-[10px] font-bold text-slate-500 uppercase tracking-widest" />
               </tr>
             </thead>
             <tbody className="divide-y divide-slate-100">
               {loading ? (
-                <tr><td colSpan={9} className="text-center py-12 text-sm text-slate-400">Loading...</td></tr>
-              ) : claims.length === 0 ? (
-                <tr><td colSpan={9} className="text-center py-12 text-sm text-slate-400">No claims found.</td></tr>
-              ) : claims.map((claim) => (
-                <tr key={claim.case_id} className="hover:bg-slate-50/60 transition-colors">
-                  <td className="px-5 py-3 text-xs font-mono font-bold text-indigo-600">
-                    <Link to={`/claims/${claim.case_id}`} className="hover:underline">{claim.case_id}</Link>
-                  </td>
-                  <td className="px-5 py-3 text-xs font-mono text-slate-700">
-                    <Link to={`/providers/${claim.npi}`} className="hover:text-indigo-600 hover:underline">{claim.npi}</Link>
-                  </td>
-                  <td className="px-5 py-3 text-xs font-mono text-slate-700">{claim.hcpcs_cd}</td>
-                  <td className="px-5 py-3 text-xs text-right text-slate-700">{claim.tot_srvcs?.toLocaleString() ?? '—'}</td>
-                  <td className="px-5 py-3 text-xs text-right text-slate-700">{claim.tot_benes?.toLocaleString() ?? '—'}</td>
-                  <td className="px-5 py-3 text-xs text-right text-slate-700">{formatUSD(claim.avg_submitted_charge)}</td>
-                  <td className={cn('px-5 py-3 text-xs text-right font-bold', scoreColor(claim.seed_risk_score))}>{claim.seed_risk_score ?? '—'}</td>
-                  <td className="px-5 py-3">
-                    <span className={cn('px-2 py-0.5 rounded-full text-[10px] font-bold uppercase', claim.seed_case_label?.includes('high') ? 'bg-rose-100 text-rose-700' : claim.seed_case_label?.includes('review') ? 'bg-amber-100 text-amber-700' : 'bg-emerald-100 text-emerald-700')}>
-                      {claim.seed_case_label ?? '—'}
-                    </span>
-                  </td>
-                  <td className="px-5 py-3">
-                    <Link to={`/claims/${claim.case_id}`} className="text-slate-400 hover:text-indigo-600"><ExternalLink className="w-4 h-4" /></Link>
+                <tr>
+                  <td
+                    colSpan={9}
+                    className="text-center py-12 text-sm text-slate-400"
+                  >
+                    Loading...
                   </td>
                 </tr>
-              ))}
+              ) : claims.length === 0 ? (
+                <tr>
+                  <td
+                    colSpan={9}
+                    className="text-center py-12 text-sm text-slate-400"
+                  >
+                    No claims found.
+                  </td>
+                </tr>
+              ) : (
+                claims.map((claim) => (
+                  <tr
+                    key={claim.case_id}
+                    className="hover:bg-slate-50/60 transition-colors"
+                  >
+                    <td className="px-5 py-3 text-xs font-mono font-bold text-indigo-600">
+                      <Link
+                        to={`/claims/${claim.case_id}`}
+                        className="hover:underline"
+                      >
+                        {formatCaseId(claim.case_id)}
+                      </Link>
+                    </td>
+                    <td className="px-5 py-3 text-xs font-mono text-slate-700">
+                      <Link
+                        to={`/providers/${claim.npi}`}
+                        className="hover:text-indigo-600 hover:underline"
+                      >
+                        {claim.npi}
+                      </Link>
+                    </td>
+                    <td className="px-5 py-3 text-xs font-mono text-slate-700">
+                      {claim.hcpcs_cd}
+                    </td>
+                    <td className="px-5 py-3 text-xs text-right text-slate-700">
+                      {claim.tot_srvcs?.toLocaleString() ?? "—"}
+                    </td>
+                    <td className="px-5 py-3 text-xs text-right text-slate-700">
+                      {claim.tot_benes?.toLocaleString() ?? "—"}
+                    </td>
+                    <td className="px-5 py-3 text-xs text-right text-slate-700">
+                      {formatUSD(claim.avg_submitted_charge)}
+                    </td>
+                    <td
+                      className={cn(
+                        "px-5 py-3 text-xs text-right font-bold",
+                        scoreColor(claim.seed_risk_score),
+                      )}
+                    >
+                      {claim.seed_risk_score ?? "—"}
+                    </td>
+                    <td className="px-5 py-3">
+                      <StatusBadge
+                        band={claim.seed_case_label as RiskBand | null}
+                        size="sm"
+                      />
+                    </td>
+                    <td className="px-5 py-3">
+                      <Link
+                        to={`/claims/${claim.case_id}`}
+                        className="text-slate-400 hover:text-indigo-600"
+                      >
+                        <ExternalLink className="w-4 h-4" />
+                      </Link>
+                    </td>
+                  </tr>
+                ))
+              )}
             </tbody>
           </table>
         </div>
 
         {/* Pagination */}
         <div className="flex items-center justify-between px-5 py-4 border-t border-slate-100 bg-slate-50/40">
-          <p className="text-xs text-slate-500">Page {meta.page} of {meta.pages} ({meta.total.toLocaleString()} total)</p>
+          <p className="text-xs text-slate-500">
+            Page {meta.page} of {meta.pages} ({meta.total.toLocaleString()}{" "}
+            total)
+          </p>
           <div className="flex items-center gap-2">
-            <button disabled={page <= 1} onClick={() => setPage((p) => p - 1)} className="p-2 rounded-lg border border-slate-200 bg-white text-slate-500 hover:bg-slate-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors">
+            <button
+              disabled={page <= 1}
+              onClick={() => setPage((p) => p - 1)}
+              className="p-2 rounded-lg border border-slate-200 bg-white text-slate-500 hover:bg-slate-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+            >
               <ChevronLeft className="w-4 h-4" />
             </button>
-            <button disabled={page >= meta.pages} onClick={() => setPage((p) => p + 1)} className="p-2 rounded-lg border border-slate-200 bg-white text-slate-500 hover:bg-slate-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors">
+            <button
+              disabled={page >= meta.pages}
+              onClick={() => setPage((p) => p + 1)}
+              className="p-2 rounded-lg border border-slate-200 bg-white text-slate-500 hover:bg-slate-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+            >
               <ChevronRight className="w-4 h-4" />
             </button>
           </div>

--- a/frontend/src/pages/Investigations.tsx
+++ b/frontend/src/pages/Investigations.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
-import { ClipboardList, AlertTriangle, ChevronRight } from 'lucide-react';
-import { getPendingCases } from '../lib/api';
-import type { PendingCase } from '../lib/api';
-import { cn } from '../lib/utils';
-import { scoreColor, formatUSD } from '../lib/helpers';
+import React from "react";
+import { Link } from "react-router-dom";
+import { ClipboardList, AlertTriangle, ChevronRight } from "lucide-react";
+import { getPendingCases } from "../lib/api";
+import type { PendingCase, RiskBand } from "../lib/api";
+import { StatusBadge } from "../components/StatusBadge";
+import { cn } from "../lib/utils";
+import { scoreColor, formatUSD, formatCaseId } from "../lib/helpers";
 
 export function Investigations() {
   const [cases, setCases] = React.useState<PendingCase[]>([]);
@@ -13,10 +14,16 @@ export function Investigations() {
   React.useEffect(() => {
     let active = true;
     getPendingCases(100)
-      .then((d) => { if (active) setCases(d); })
+      .then((d) => {
+        if (active) setCases(d);
+      })
       .catch(() => {})
-      .finally(() => { if (active) setLoading(false); });
-    return () => { active = false; };
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
   }, []);
 
   return (
@@ -24,7 +31,9 @@ export function Investigations() {
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
         <div>
           <h1 className="text-2xl font-bold text-slate-900">Investigations</h1>
-          <p className="mt-1 text-sm text-slate-500">Pending high-risk cases requiring analyst review and action.</p>
+          <p className="mt-1 text-sm text-slate-500">
+            Pending high-risk cases requiring analyst review and action.
+          </p>
         </div>
         <div className="flex items-center gap-2 text-xs text-slate-500 font-medium bg-amber-50 border border-amber-200 px-3 py-1.5 rounded-lg">
           <AlertTriangle className="w-3.5 h-3.5 text-amber-500" />
@@ -40,33 +49,60 @@ export function Investigations() {
         <div className="flex flex-col items-center justify-center py-16 bg-white rounded-2xl border border-dashed border-slate-200">
           <ClipboardList className="w-12 h-12 text-emerald-400 mb-4" />
           <h3 className="text-lg font-bold text-slate-800 mb-2">All Clear</h3>
-          <p className="text-sm text-slate-500">No pending investigations at this time.</p>
+          <p className="text-sm text-slate-500">
+            No pending investigations at this time.
+          </p>
         </div>
       ) : (
         <div className="space-y-3">
           {cases.map((c) => (
-            <Link key={c.case_id} to={`/investigations/${c.case_id}`} className="block bg-white rounded-xl border border-slate-200 shadow-sm hover:border-indigo-200 hover:shadow-md transition-all p-5 group">
+            <Link
+              key={c.case_id}
+              to={`/investigations/${c.case_id}`}
+              className="block bg-white rounded-xl border border-slate-200 shadow-sm hover:border-indigo-200 hover:shadow-md transition-all p-5 group"
+            >
               <div className="flex items-center justify-between gap-4">
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-3 mb-2">
-                    <span className="text-sm font-bold text-indigo-600 font-mono">{c.case_id}</span>
-                    <span className={cn('px-2 py-0.5 rounded-full text-[10px] font-bold uppercase', c.seed_case_label?.includes('high') ? 'bg-rose-100 text-rose-700' : c.seed_case_label?.includes('review') ? 'bg-amber-100 text-amber-700' : 'bg-emerald-100 text-emerald-700')}>
-                      {c.seed_case_label ?? '—'}
+                    <span className="text-sm font-bold text-indigo-600 font-mono">
+                      {formatCaseId(c.case_id)}
                     </span>
+                    <StatusBadge
+                      band={c.seed_case_label as RiskBand | null}
+                      size="sm"
+                    />
                   </div>
                   <div className="flex flex-wrap items-center gap-x-5 gap-y-1 text-xs text-slate-500">
-                    <span>NPI: <span className="font-mono font-medium text-slate-700">{c.npi}</span></span>
-                    <span>{c.provider_last_org_name ?? '—'}</span>
-                    <span>HCPCS: <span className="font-mono">{c.hcpcs_cd}</span></span>
-                    {c.hcpcs_desc && <span className="text-slate-400">{c.hcpcs_desc}</span>}
-                    <span>Services: {c.tot_srvcs ?? '—'}</span>
+                    <span>
+                      NPI:{" "}
+                      <span className="font-mono font-medium text-slate-700">
+                        {c.npi}
+                      </span>
+                    </span>
+                    <span>{c.provider_last_org_name ?? "—"}</span>
+                    <span>
+                      HCPCS: <span className="font-mono">{c.hcpcs_cd}</span>
+                    </span>
+                    {c.hcpcs_desc && (
+                      <span className="text-slate-400">{c.hcpcs_desc}</span>
+                    )}
+                    <span>Services: {c.tot_srvcs ?? "—"}</span>
                     <span>Charge: {formatUSD(c.avg_submitted_charge)}</span>
                   </div>
                 </div>
                 <div className="flex items-center gap-4">
                   <div className="text-right">
-                    <p className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">Risk</p>
-                    <p className={cn('text-2xl font-black', scoreColor(c.seed_risk_score))}>{c.seed_risk_score ?? '—'}</p>
+                    <p className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">
+                      Risk
+                    </p>
+                    <p
+                      className={cn(
+                        "text-2xl font-black",
+                        scoreColor(c.seed_risk_score),
+                      )}
+                    >
+                      {c.seed_risk_score ?? "—"}
+                    </p>
                   </div>
                   <ChevronRight className="w-5 h-5 text-slate-300 group-hover:text-indigo-400 transition-colors" />
                 </div>

--- a/frontend/src/pages/LiveMonitor.tsx
+++ b/frontend/src/pages/LiveMonitor.tsx
@@ -389,18 +389,17 @@ export function LiveMonitor() {
                     <motion.circle
                       r={6}
                       fill={labelColor(evt.case_label)}
-                      opacity={0.9}
-                      initial={{ r: 0, opacity: 0 }}
-                      animate={{ r: [0, 10, 6], opacity: [0, 1, 0.9] }}
+                      initial={{ scale: 0, opacity: 0 }}
+                      animate={{ scale: [0, 1.6, 1], opacity: [0, 1, 0.9] }}
                       transition={{ duration: 0.6, ease: "easeOut" }}
                     />
                     <motion.circle
-                      r={6}
+                      r={8}
                       fill="none"
                       stroke={labelColor(evt.case_label)}
                       strokeWidth={1.5}
-                      opacity={0}
-                      animate={{ r: [6, 18], opacity: [0.6, 0] }}
+                      initial={{ scale: 1, opacity: 0.6 }}
+                      animate={{ scale: [1, 2.5], opacity: [0.6, 0] }}
                       transition={{
                         duration: 1.5,
                         repeat: Infinity,

--- a/frontend/src/pages/Providers.tsx
+++ b/frontend/src/pages/Providers.tsx
@@ -1,22 +1,38 @@
-import React from 'react';
-import { cn } from '../lib/utils';
-import { Search, Download, MapPin, Stethoscope, ExternalLink } from 'lucide-react';
-import { Link, useSearchParams } from 'react-router-dom';
-import { getProviders } from '../lib/api';
-import type { ProviderSummary, PaginationMeta } from '../lib/api';
-import { StatusBadge } from '../components/StatusBadge';
-import { formatCompactUSD, scoreColor, providerDisplayName } from '../lib/helpers';
+import React from "react";
+import { cn } from "../lib/utils";
+import {
+  Search,
+  Download,
+  MapPin,
+  Stethoscope,
+  ExternalLink,
+} from "lucide-react";
+import { Link, useSearchParams, useNavigate } from "react-router-dom";
+import { getProviders } from "../lib/api";
+import type { ProviderSummary, PaginationMeta } from "../lib/api";
+import { StatusBadge } from "../components/StatusBadge";
+import {
+  formatCompactUSD,
+  scoreColor,
+  providerDisplayName,
+} from "../lib/helpers";
 
 export function Providers() {
+  const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const initialState = searchParams.get('state') || '';
-  const initialRiskBand = searchParams.get('risk_band') || '';
+  const initialState = searchParams.get("state") || "";
+  const initialRiskBand = searchParams.get("risk_band") || "";
 
-  const [searchTerm, setSearchTerm] = React.useState('');
+  const [searchTerm, setSearchTerm] = React.useState("");
   const [stateFilter, setStateFilter] = React.useState(initialState);
   const [riskBandFilter, setRiskBandFilter] = React.useState(initialRiskBand);
   const [providers, setProviders] = React.useState<ProviderSummary[]>([]);
-  const [meta, setMeta] = React.useState<PaginationMeta>({ total: 0, page: 1, per_page: 50, pages: 1 });
+  const [meta, setMeta] = React.useState<PaginationMeta>({
+    total: 0,
+    page: 1,
+    per_page: 50,
+    pages: 1,
+  });
 
   React.useEffect(() => {
     let active = true;
@@ -39,7 +55,9 @@ export function Providers() {
           setMeta({ total: 0, page: 1, per_page: 50, pages: 1 });
         }
       });
-    return () => { active = false; };
+    return () => {
+      active = false;
+    };
   }, [meta.page, searchTerm, stateFilter, riskBandFilter]);
 
   React.useEffect(() => {
@@ -50,8 +68,12 @@ export function Providers() {
     <div className="space-y-6 animate-in fade-in slide-in-from-bottom-4 duration-500">
       <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
         <div>
-          <h1 className="text-2xl font-bold text-slate-900 tracking-tight">Providers</h1>
-          <p className="text-slate-500 text-sm mt-1">Manage and investigate healthcare provider risk profiles.</p>
+          <h1 className="text-2xl font-bold text-slate-900 tracking-tight">
+            Providers
+          </h1>
+          <p className="text-slate-500 text-sm mt-1">
+            Manage and investigate healthcare provider risk profiles.
+          </p>
         </div>
         <button className="flex items-center gap-2 px-3 py-1.5 bg-white border border-slate-200 rounded-md text-sm font-medium text-slate-600 hover:bg-slate-50 transition-colors shadow-sm">
           <Download className="w-4 h-4" />
@@ -62,13 +84,19 @@ export function Providers() {
       {/* Summary */}
       <div className="bg-indigo-900 text-white rounded-xl p-4 flex flex-wrap items-center gap-8 shadow-lg shadow-indigo-200">
         <div>
-          <p className="text-indigo-300 text-[10px] font-bold uppercase tracking-wider">Total Results</p>
+          <p className="text-indigo-300 text-[10px] font-bold uppercase tracking-wider">
+            Total Results
+          </p>
           <p className="text-xl font-bold">{meta.total.toLocaleString()}</p>
         </div>
         <div className="w-px h-8 bg-indigo-800 hidden sm:block" />
         <div>
-          <p className="text-indigo-300 text-[10px] font-bold uppercase tracking-wider">Page</p>
-          <p className="text-xl font-bold">{meta.page} / {meta.pages}</p>
+          <p className="text-indigo-300 text-[10px] font-bold uppercase tracking-wider">
+            Page
+          </p>
+          <p className="text-xl font-bold">
+            {meta.page} / {meta.pages}
+          </p>
         </div>
       </div>
 
@@ -89,7 +117,9 @@ export function Providers() {
           placeholder="State (e.g. FL)"
           className="bg-slate-50 border border-slate-200 rounded-lg px-3 py-2 text-sm font-medium text-slate-600 outline-none focus:ring-2 focus:ring-indigo-500 w-32"
           value={stateFilter}
-          onChange={(e) => setStateFilter(e.target.value.toUpperCase().slice(0, 2))}
+          onChange={(e) =>
+            setStateFilter(e.target.value.toUpperCase().slice(0, 2))
+          }
         />
         <select
           value={riskBandFilter}
@@ -109,46 +139,78 @@ export function Providers() {
           <table className="w-full text-sm text-left">
             <thead>
               <tr className="bg-slate-50 border-b border-slate-200">
-                <th className="px-6 py-4 font-semibold text-slate-600 uppercase text-[10px] tracking-wider">Provider</th>
-                <th className="px-6 py-4 font-semibold text-slate-600 uppercase text-[10px] tracking-wider">Type</th>
-                <th className="px-6 py-4 font-semibold text-slate-600 uppercase text-[10px] tracking-wider">Location</th>
-                <th className="px-6 py-4 font-semibold text-slate-600 uppercase text-[10px] tracking-wider">Est. Payment</th>
-                <th className="px-6 py-4 font-semibold text-slate-600 uppercase text-[10px] tracking-wider">Risk Band</th>
-                <th className="px-6 py-4 font-semibold text-slate-600 uppercase text-[10px] tracking-wider text-right">Score</th>
+                <th className="px-6 py-4 font-semibold text-slate-600 uppercase text-[10px] tracking-wider">
+                  Provider
+                </th>
+                <th className="px-6 py-4 font-semibold text-slate-600 uppercase text-[10px] tracking-wider">
+                  Type
+                </th>
+                <th className="px-6 py-4 font-semibold text-slate-600 uppercase text-[10px] tracking-wider">
+                  Location
+                </th>
+                <th className="px-6 py-4 font-semibold text-slate-600 uppercase text-[10px] tracking-wider">
+                  Est. Payment
+                </th>
+                <th className="px-6 py-4 font-semibold text-slate-600 uppercase text-[10px] tracking-wider">
+                  Risk Band
+                </th>
+                <th className="px-6 py-4 font-semibold text-slate-600 uppercase text-[10px] tracking-wider text-right">
+                  Score
+                </th>
                 <th className="px-6 py-4"></th>
               </tr>
             </thead>
             <tbody className="divide-y divide-slate-100">
               {providers.map((p) => (
-                <tr key={p.npi} className="group hover:bg-slate-50 transition-colors cursor-pointer">
+                <tr
+                  key={p.npi}
+                  className="group hover:bg-slate-50 transition-colors cursor-pointer"
+                  onClick={() => navigate(`/providers/${p.npi}`)}
+                >
                   <td className="px-6 py-4">
                     <Link to={`/providers/${p.npi}`} className="block">
-                      <div className="font-bold text-slate-900 group-hover:text-indigo-600 transition-colors">{providerDisplayName(p)}</div>
-                      <div className="text-xs text-slate-400 font-mono">NPI: {p.npi}</div>
+                      <div className="font-bold text-slate-900 group-hover:text-indigo-600 transition-colors">
+                        {providerDisplayName(p)}
+                      </div>
+                      <div className="text-xs text-slate-400 font-mono">
+                        NPI: {p.npi}
+                      </div>
                     </Link>
                   </td>
                   <td className="px-6 py-4">
                     <div className="flex items-center gap-1.5 text-slate-600">
                       <Stethoscope className="w-3.5 h-3.5 text-slate-400" />
-                      {p.provider_type ?? '—'}
+                      {p.provider_type ?? "—"}
                     </div>
                   </td>
                   <td className="px-6 py-4">
                     <div className="flex items-center gap-1.5 text-slate-600">
                       <MapPin className="w-3.5 h-3.5 text-slate-400" />
-                      {p.city ?? '—'}, {p.state ?? '—'}
+                      {p.city ?? "—"}, {p.state ?? "—"}
                     </div>
                   </td>
-                  <td className="px-6 py-4 font-medium text-slate-700">{formatCompactUSD(p.total_estimated_payment)}</td>
-                  <td className="px-6 py-4"><StatusBadge band={p.risk_band} size="sm" /></td>
+                  <td className="px-6 py-4 font-medium text-slate-700">
+                    {formatCompactUSD(p.total_estimated_payment)}
+                  </td>
+                  <td className="px-6 py-4">
+                    <StatusBadge band={p.risk_band} size="sm" />
+                  </td>
                   <td className="px-6 py-4 text-right">
-                    <span className={cn('font-bold text-sm', scoreColor(p.max_seed_risk_score))}>
-                      {p.max_seed_risk_score ?? '—'}
+                    <span
+                      className={cn(
+                        "font-bold text-sm",
+                        scoreColor(p.max_seed_risk_score),
+                      )}
+                    >
+                      {p.max_seed_risk_score ?? "—"}
                     </span>
                   </td>
                   <td className="px-6 py-4 text-right">
                     <div className="flex items-center justify-end gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
-                      <Link to={`/providers/${p.npi}`} className="p-1.5 text-slate-400 hover:text-indigo-600 hover:bg-indigo-50 rounded transition-colors">
+                      <Link
+                        to={`/providers/${p.npi}`}
+                        className="p-1.5 text-slate-400 hover:text-indigo-600 hover:bg-indigo-50 rounded transition-colors"
+                      >
                         <ExternalLink className="w-4 h-4" />
                       </Link>
                     </div>
@@ -160,19 +222,35 @@ export function Providers() {
         </div>
 
         <div className="bg-slate-50 px-6 py-4 border-t border-slate-200 flex items-center justify-between">
-          <p className="text-xs text-slate-500">Page {meta.page} of {meta.pages} · {meta.total} provider(s)</p>
+          <p className="text-xs text-slate-500">
+            Page {meta.page} of {meta.pages} · {meta.total} provider(s)
+          </p>
           <div className="flex items-center gap-2">
             <button
-              onClick={() => setMeta((c) => ({ ...c, page: Math.max(1, c.page - 1) }))}
+              onClick={() =>
+                setMeta((c) => ({ ...c, page: Math.max(1, c.page - 1) }))
+              }
               disabled={meta.page <= 1}
-              className={cn('px-3 py-1 bg-white border border-slate-200 rounded text-xs font-medium', meta.page <= 1 ? 'text-slate-400 cursor-not-allowed' : 'text-slate-600 hover:bg-slate-50')}
+              className={cn(
+                "px-3 py-1 bg-white border border-slate-200 rounded text-xs font-medium",
+                meta.page <= 1
+                  ? "text-slate-400 cursor-not-allowed"
+                  : "text-slate-600 hover:bg-slate-50",
+              )}
             >
               Previous
             </button>
             <button
-              onClick={() => setMeta((c) => ({ ...c, page: Math.min(c.pages, c.page + 1) }))}
+              onClick={() =>
+                setMeta((c) => ({ ...c, page: Math.min(c.pages, c.page + 1) }))
+              }
               disabled={meta.page >= meta.pages}
-              className={cn('px-3 py-1 bg-white border border-slate-200 rounded text-xs font-medium', meta.page >= meta.pages ? 'text-slate-400 cursor-not-allowed' : 'text-slate-600 hover:bg-slate-50')}
+              className={cn(
+                "px-3 py-1 bg-white border border-slate-200 rounded text-xs font-medium",
+                meta.page >= meta.pages
+                  ? "text-slate-400 cursor-not-allowed"
+                  : "text-slate-600 hover:bg-slate-50",
+              )}
             >
               Next
             </button>


### PR DESCRIPTION
## Summary
- **#371**: Replace inline label with `StatusBadge` in Claims + Investigations — "High Risk" instead of "HIGH_RISK"
- **#370**: Fix `motion.circle` console errors on Live Monitor — use `scale` transform instead of animating SVG `r` attribute
- **#375**: Add `onClick` to Provider table rows — clicking anywhere navigates to detail
- **#376**: Add `formatCaseId()` helper — shows "NPI — HCPCS" instead of raw pipe-delimited IDs

Closes #371, closes #370, closes #375, closes #376

## Test plan
- [ ] Claims page shows "High Risk" / "Review" / "Stable" badges (not uppercase underscore)
- [ ] Investigations page same
- [ ] Live Monitor map dots pulse without console errors
- [ ] Clicking a provider row navigates to `/providers/:npi`
- [ ] Claims Case ID column shows "1821387911 — 90677" format
- [ ] Investigations card titles same format