### PR TITLE
docs: add FPS complement framing and UPIC terminology (#361)

### DIFF
--- a/docs/path-to-cms-pilot.md
+++ b/docs/path-to-cms-pilot.md
@@ -63,6 +63,19 @@ The system is designed so the **MVP maps directly to a pilot** with minimal rewo
 - No PHI required — works on public data today
 - **Validated**: 91% of eventually-revoked providers detected from billing patterns alone (94% for billing abuse, 100% for felony-related revocations)
 
+## Integration with Existing CMS Systems
+
+CMS already operates the **Fraud Prevention System (FPS)**, a real-time pre-payment scoring engine that processes approximately 15 million Medicare Fee-for-Service claim lines per day (operated by Peraton under a CMS contract). FPS generates provider risk, priority, and actionability scores that feed investigation queues for **Unified Program Integrity Contractors (UPICs)** — the five regional contractors who replaced ZPICs in 2016–2019 and are required by CMS to derive 45% of new investigations from FPS leads. In 2025, CMS also launched the Fraud Detection Operation Center (FDOC) using FPS outputs.
+
+Argus is designed to be **complementary to FPS, not a replacement**:
+
+- **FPS** screens claims at the transaction level — it scores individual claim lines pre-payment.
+- **Argus** profiles providers at the behavioral level — it builds an explainable evidence picture across a provider's full billing history, peer group, enrollment status, and sanctions record.
+
+The integration point is straightforward: FPS-flagged NPIs become investigation triggers in Argus. A UPIC investigator receives an FPS lead (a risk score on a claim), then uses Argus to answer the harder question — _why does this provider's overall billing pattern look suspicious, and what evidence supports that conclusion?_
+
+This directly addresses a documented gap. GAO Report GAO-17-710 criticized FPS for lacking defined effectiveness measures and transparency in how risk scores are generated. Argus addresses this with 13 named signals, each with a threshold, a weight, and a data-source citation — the kind of provenance that supports an administrative action or law enforcement referral.
+
 ### Pilot Phase (6 months)
 
 | Change                           | What It Takes                                                                                                                                                                                    |
@@ -74,6 +87,8 @@ The system is designed so the **MVP maps directly to a pilot** with minimal rewo
 | **Real-time scoring**            | The system already demonstrates real-time scoring at sub-50ms latency via SSE streaming. Connecting to a live CMS claims feed (SQS/Kafka) is a configuration change, not an architecture change. |
 | **Multi-year temporal analysis** | Connect 3-5 years of Part B data to detect year-over-year growth, billing acceleration, and code-mix shifts.                                                                                     |
 | **Feedback loop**                | Reviewer decisions (true positive, false positive) feed back into signal weight tuning.                                                                                                          |
+| **FPS lead ingestion**           | Ingest provider NPIs flagged by FPS as investigation triggers. Configuration change, not architecture change.                                                                                    |
+| **UCM integration**              | Push Argus evidence packages to CMS Unified Case Management system for UPIC workflow.                                                                                                            |
 
 ### Production Scale (12 months)
 

--- a/docs/personas.md
+++ b/docs/personas.md
@@ -12,7 +12,7 @@ Argus sits at the payment gate. It scores every claim against peer baselines, fl
 
 ### 1. Claims Processing Analyst — "Sarah"
 
-**Role**: GS-9 Program Analyst, CMS Center for Program Integrity
+**Role**: GS-9 Program Analyst, UPIC
 
 **Day-to-day**: Reviews 200+ claims per day from the flagged queue. Makes binary decisions: pay or flag for investigation. Works under time pressure — the payment cycle doesn't wait.
 
@@ -27,6 +27,7 @@ Argus sits at the payment gate. It scores every claim against peer baselines, fl
 - Current tools show raw data with no context — she has to manually compare charges against fee schedules
 - No explanation of _why_ a claim is suspicious — just a number
 - Switching between 4 different systems to get the full picture
+- FPS flags claims but doesn't explain why a provider's overall billing pattern is suspicious
 
 **What Argus gives her**:
 
@@ -43,7 +44,7 @@ Argus sits at the payment gate. It scores every claim against peer baselines, fl
 
 ### 2. Special Investigations Unit (SIU) Investigator — "Marcus"
 
-**Role**: GS-12 Fraud Investigator, Zone Program Integrity Contractor (ZPIC)
+**Role**: GS-12 Fraud Investigator, UPIC
 
 **Day-to-day**: Receives escalated cases from analysts. Builds evidence packages for administrative action or law enforcement referral. Each case takes 2-8 hours with current tools.
 
@@ -58,6 +59,7 @@ Argus sits at the payment gate. It scores every claim against peer baselines, fl
 - Evidence is scattered across multiple databases — Medicare claims, enrollment, revocation lists
 - No way to visualize provider relationships without manual diagramming
 - Writing case narratives from scratch every time
+- FPS leads arrive as risk scores without provider-level behavioral context
 
 **What Argus gives him**:
 

--- a/docs/problem-statement.md
+++ b/docs/problem-statement.md
@@ -23,6 +23,8 @@ That creates three operational problems:
 3. Publicly understandable, cross-program context is fragmented across billing, enrollment,
    sanctions, and financial-relationship data.
 
+CMS operates the Fraud Prevention System (FPS) for claim-level pre-payment screening, but FPS does not provide the provider-behavioral explainability that investigators need to build evidence cases.
+
 ## The Opportunity
 
 Public CMS and HHS data already contain enough signal to build a proactive decision-support layer


### PR DESCRIPTION
Closes #361

## Summary

- `docs/path-to-cms-pilot.md`: Added new "Integration with Existing CMS Systems" section between "Already Production-Ready Today" and "Pilot Phase", naming FPS (15M claims/day, Peraton), UPICs, the FPS→Argus integration point, and the GAO-17-710 explainability gap. Added two new rows to the Pilot Phase table: FPS lead ingestion and UCM integration.
- `docs/personas.md`: Updated Sarah's and Marcus's roles from ZPIC/CPI to UPIC. Added a pain point to each persona calling out FPS's lack of provider-behavioral explainability.
- `docs/problem-statement.md`: Added one sentence after the three operational problems naming FPS and its explainability gap.

No code changes.