### PR TITLE
feat(ai): context-aware provider chat with SQL fallback

### DIFF
--- a/frontend/src/components/AssistantDrawer.tsx
+++ b/frontend/src/components/AssistantDrawer.tsx
@@ -91,7 +91,7 @@ export function AssistantDrawer({
     setLoading(true);
 
     try {
-      const response = await chat(content, history);
+      const response = await chat(content, history, context.entityId || undefined);
       const assistantMsg = {
         id: nextId(),
         role: "assistant" as const,

--- a/frontend/src/components/__tests__/AssistantDrawer.test.tsx
+++ b/frontend/src/components/__tests__/AssistantDrawer.test.tsx
@@ -98,7 +98,7 @@ describe("AssistantDrawer", () => {
     await user.type(textarea, "What is the risk?");
     await user.keyboard("{Enter}");
     await waitFor(() => {
-      expect(chat).toHaveBeenCalledWith("What is the risk?", []);
+      expect(chat).toHaveBeenCalledWith("What is the risk?", [], "NPI-001");
     });
     await waitFor(() => {
       expect(
@@ -144,6 +144,7 @@ describe("AssistantDrawer", () => {
       expect(chat).toHaveBeenCalledWith(
         "What are the top risk signals for this provider?",
         [],
+        "NPI-001",
       );
     });
   });
@@ -272,7 +273,7 @@ describe("AssistantDrawer", () => {
     expect(sendBtn).toBeDefined();
     await user.click(sendBtn!);
     await waitFor(() => {
-      expect(chat).toHaveBeenCalledWith("Via button", []);
+      expect(chat).toHaveBeenCalledWith("Via button", [], "NPI-001");
     });
   });
 
@@ -316,4 +317,24 @@ describe("AssistantDrawer", () => {
     });
     expect(screen.queryByText("SQL")).not.toBeInTheDocument();
   });
+
+  it("passes undefined npi when entityId is empty", async () => {
+    vi.mocked(chat).mockResolvedValue(mockResponse);
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(
+      <AssistantDrawer
+        isOpen={true}
+        onClose={onClose}
+        context={{ type: "provider", entityId: "", label: "Empty" }}
+      />,
+    );
+    const textarea = screen.getByPlaceholderText("Ask about this provider...");
+    await user.type(textarea, "Test query");
+    await user.keyboard("{Enter}");
+    await waitFor(() => {
+      expect(chat).toHaveBeenCalledWith("Test query", [], undefined);
+    });
+  });
+
 });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -627,10 +627,10 @@ export function getFairness(params?: { threshold?: number; blind?: boolean }) {
   return request<FairnessReport>(`/api/fairness${suffix}`);
 }
 
-export function chat(message: string, history: ChatMessage[] = []) {
+export function chat(message: string, history: ChatMessage[] = [], npi?: string) {
   return request<ChatResponse>("/api/chat", {
     method: "POST",
-    body: { message, history },
+    body: { message, history, ...(npi && { npi }) },
   });
 }
 

--- a/src/ai/text_to_sql.py
+++ b/src/ai/text_to_sql.py
@@ -68,15 +68,16 @@ def validate_sql(sql: str) -> str:
     if _MULTI_STATEMENT.search(cleaned):
         raise SQLValidationError("Multiple statements are not allowed")
 
-    if not _ALLOWED_START.match(cleaned):
-        raise SQLValidationError(f"SQL must start with SELECT or WITH, got: {cleaned[:50]}")
-
-    # Strip string literals before checking forbidden patterns so that
-    # legitimate values like 'Credit Union Bank' don't false-positive.
+    # Check forbidden keywords BEFORE the SELECT/WITH check so that
+    # dangerous statements (DROP, DELETE) are caught even when
+    # provider_context would treat them as direct answers.
     stripped = re.sub(r"'[^']*'", "''", cleaned)
     forbidden = _FORBIDDEN_PATTERNS.search(stripped)
     if forbidden:
         raise SQLValidationError(f"Forbidden keyword: {forbidden.group()}")
+
+    if not _ALLOWED_START.match(cleaned):
+        raise SQLValidationError(f"SQL must start with SELECT or WITH, got: {cleaned[:50]}")
 
     # Add LIMIT if missing
     if not re.search(r"\bLIMIT\b", cleaned, re.IGNORECASE):
@@ -90,19 +91,34 @@ async def text_to_sql(
     conn: AsyncConnection,
     *,
     history: list[dict[str, str]] | None = None,
+    provider_context: str | None = None,
     model: str = CHAT_MODEL,
 ) -> dict[str, Any]:
     """Convert natural language question to SQL, execute, return results.
 
+    When provider_context is supplied, Claude may answer directly from the
+    context without generating SQL. If the response is not valid SQL,
+    we return it as a direct text answer instead of raising.
+
     Returns dict with keys:
         - answer: formatted text answer
-        - sql: the generated SQL query
+        - sql: the generated SQL query (None for direct answers)
         - columns: list of column names
         - rows: list of row dicts
         - row_count: number of rows returned
         - duration_ms: query execution time
     """
     system_prompt = build_text_to_sql_system_prompt()
+    if provider_context:
+        system_prompt += (
+            "\n\n## Current Provider Context\n"
+            f"{provider_context}\n\n"
+            "Answer directly from this context when the data is sufficient. "
+            "Only generate a SQL query when the question requires data NOT "
+            "shown above (e.g. peer comparisons, state-level aggregates, "
+            "other providers). For direct answers, respond with natural "
+            "language \u2014 no SQL."
+        )
 
     # Build messages with conversation history for context
     messages: list[dict[str, str]] = []
@@ -119,14 +135,36 @@ async def text_to_sql(
         temperature=0.0,
     )
 
-    raw_sql = response["text"].strip()
+    raw_response = response["text"].strip()
 
     # Strip markdown code fences if present
-    if raw_sql.startswith("```"):
-        raw_sql = re.sub(r"^```(?:sql)?\s*", "", raw_sql)
-        raw_sql = re.sub(r"\s*```$", "", raw_sql)
+    cleaned = raw_response
+    if cleaned.startswith("```"):
+        cleaned = re.sub(r"^```(?:sql)?\s*", "", cleaned)
+        cleaned = re.sub(r"\s*```$", "", cleaned)
 
-    sql = validate_sql(raw_sql)
+    # Try to validate as SQL. If it fails and we have provider context,
+    # treat natural-language responses as direct answers.
+    try:
+        sql = validate_sql(cleaned)
+    except SQLValidationError as e:
+        err_msg = str(e)
+        is_natural_language = (
+            "SQL must start with SELECT or WITH" in err_msg
+            or "Empty SQL" in err_msg
+            or "UNANSWERABLE" in err_msg
+        )
+        if provider_context and is_natural_language:
+            logger.info("text_to_sql direct_answer question=%r", question[:80])
+            return {
+                "answer": raw_response,
+                "sql": None,
+                "columns": [],
+                "rows": [],
+                "row_count": 0,
+                "duration_ms": 0,
+            }
+        raise
 
     # Execute with timeout
     start = time.monotonic()

--- a/src/api/routes/chat.py
+++ b/src/api/routes/chat.py
@@ -11,6 +11,7 @@ import logging
 
 from fastapi import APIRouter, Depends, HTTPException
 from psycopg import AsyncConnection
+from psycopg.rows import dict_row
 
 from src.ai.chart_spec import generate_chart_spec
 from src.ai.text_to_sql import SQLValidationError, text_to_sql
@@ -35,6 +36,60 @@ def _serialize_row(row: dict) -> dict[str, object]:
     return out
 
 
+async def _build_provider_context(
+    npi: str,
+    conn: AsyncConnection,
+) -> str | None:
+    """Fetch provider data and format as a text context block."""
+    async with conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute("SELECT * FROM provider_features WHERE npi = %s", [npi])
+        pf = await cur.fetchone()
+
+    if not pf:
+        return None
+
+    name = pf.get("provider_name") or "Unknown"
+    risk = pf.get("max_seed_risk_score", "N/A")
+    n_high = pf.get("n_high_risk_lines", 0)
+    n_lines = pf.get("service_line_count", 0)
+
+    lines = [
+        f"NPI: {npi}",
+        f"Name: {name}",
+        f"Specialty: {pf.get('provider_type', 'N/A')}",
+        f"Location: {pf.get('city', '')}, {pf.get('state', '')}",
+        f"Entity: {'Individual' if pf.get('entity_code') == 'I' else 'Organization'}",
+        f"Enrolled (2025): {'Yes' if pf.get('enrolled_2025') else 'No'}",
+        f"Revoked (2026): {'Yes' if pf.get('revoked_2026') else 'No'}",
+        "",
+        "Scores:",
+        f"  Max Risk Score: {risk} (0-30 stable, 31-50 review, 51+ high_risk)",
+        f"  Avg Risk Score: {pf.get('avg_seed_risk_score', 'N/A')}",
+        f"  High-Risk Service Lines: {n_high} of {n_lines}",
+        "",
+        "Peer Z-Scores (0=mean, >2=outlier):",
+    ]
+
+    for key, label in [("mean_volume_z", "Volume"), ("mean_charge_z", "Charge")]:
+        val = pf.get(key)
+        z_str = f"{val:.2f}" if val is not None else "N/A"
+        lines.append(f"  {label}: {z_str}")
+
+    pay = pf.get("total_estimated_payment")
+    fmt_pay = f"${pay:,.0f}" if pay else "N/A"
+    lines += [
+        "",
+        "Billing Summary:",
+        f"  Total Beneficiaries: {pf.get('total_benes', 'N/A')}",
+        f"  Total Services: {pf.get('total_services', 'N/A')}",
+        f"  Total Estimated Payment: {fmt_pay}",
+        f"  Service HHI: {pf.get('service_hhi', 'N/A')}",
+        f"  Top Code Share: {pf.get('top_code_share', 'N/A')}",
+    ]
+
+    return "\n".join(lines)
+
+
 @router.post("", response_model=ChatResponse)
 async def chat(
     req: ChatRequest,
@@ -47,8 +102,17 @@ async def chat(
     """
     history = [{"role": m.role, "content": m.content} for m in req.history] or None
 
+    provider_context: str | None = None
+    if req.npi:
+        provider_context = await _build_provider_context(req.npi, conn)
+
     try:
-        result = await text_to_sql(req.message, conn, history=history)
+        result = await text_to_sql(
+            req.message,
+            conn,
+            history=history,
+            provider_context=provider_context,
+        )
     except SQLValidationError as e:
         if "UNANSWERABLE" in str(e):
             return ChatResponse(
@@ -75,7 +139,7 @@ async def chat(
         ) from None
 
     serialized_rows = [_serialize_row(r) for r in result["rows"]]
-    chart = generate_chart_spec(result["columns"], serialized_rows)
+    chart = generate_chart_spec(result["columns"], serialized_rows) if serialized_rows else None
 
     return ChatResponse(
         answer=result["answer"],

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -401,6 +401,10 @@ class ChatMessage(BaseModel):
 class ChatRequest(BaseModel):
     message: str = Field(min_length=1, max_length=1000)
     history: list[ChatMessage] = Field(default_factory=list, max_length=20)
+    npi: str | None = Field(
+        default=None,
+        description="Provider NPI for context-aware chat",
+    )
 
 
 class ChatResponse(BaseModel):

--- a/tests/test_text_to_sql.py
+++ b/tests/test_text_to_sql.py
@@ -578,3 +578,71 @@ def test_format_answer_single_col_scalar_float():
     """Scalar float result."""
     result = _format_answer("q", ["score"], [{"score": 3.14}])
     assert "3.14" in result
+
+
+# ---------------------------------------------------------------------------
+# Direct answer fallback tests (provider_context)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_direct_answer_when_context_and_natural_language():
+    """With provider_context, natural language is returned as direct answer."""
+    from src.ai.text_to_sql import text_to_sql
+
+    mock_response = {"text": "This provider has a risk score of 42."}
+
+    with patch(
+        "src.ai.text_to_sql.invoke",
+        new_callable=AsyncMock,
+        return_value=mock_response,
+    ):
+        result = await text_to_sql(
+            "What is the risk?",
+            conn=AsyncMock(),
+            provider_context="NPI: 1234567890\nRisk: 42",
+        )
+
+    assert result["answer"] == "This provider has a risk score of 42."
+    assert result["sql"] is None
+    assert result["rows"] == []
+
+
+@pytest.mark.asyncio
+async def test_direct_answer_not_triggered_without_context():
+    """Without provider_context, natural language response still raises."""
+    from src.ai.text_to_sql import text_to_sql
+
+    mock_response = {"text": "I need you to specify which provider."}
+
+    with (
+        patch(
+            "src.ai.text_to_sql.invoke",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ),
+        pytest.raises(SQLValidationError, match="SQL must start with SELECT"),
+    ):
+        await text_to_sql("What is the risk?", conn=AsyncMock())
+
+
+@pytest.mark.asyncio
+async def test_security_violation_still_raises_with_context():
+    """Forbidden keyword errors must not be swallowed even with context."""
+    from src.ai.text_to_sql import text_to_sql
+
+    mock_response = {"text": "DROP TABLE provider_features"}
+
+    with (
+        patch(
+            "src.ai.text_to_sql.invoke",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ),
+        pytest.raises(SQLValidationError, match="Forbidden keyword"),
+    ):
+        await text_to_sql(
+            "Delete everything",
+            conn=AsyncMock(),
+            provider_context="NPI: 1234567890",
+        )


### PR DESCRIPTION
## Summary

Fixes the "Ask about this provider" chat failing with SQL validation errors. When chat opens on a provider page, the NPI is now passed to the backend which pre-fetches provider data and injects it as context.

**Before:** User asks "What are the risk signals?" → Claude has no NPI → responds with "I need you to specify which provider" → fails SQL validation → 422 error.

**After:** Provider context (scores, location, billing, z-scores) injected into prompt → Claude answers directly from context → no SQL needed for most questions. Falls back to SQL for cross-provider/aggregate queries.

## Changes

| File | What |
|------|------|
| `src/api/schemas.py` | Add `npi` to `ChatRequest` |
| `src/api/routes/chat.py` | `_build_provider_context()` fetches `provider_features`, formats as text |
| `src/ai/text_to_sql.py` | Accept `provider_context`, append to prompt, fall back to direct answer on validation failure |
| `frontend/src/lib/api.ts` | Add `npi` param to `chat()` |
| `frontend/src/components/AssistantDrawer.tsx` | Pass `context.entityId` as `npi` |

## Test plan
- [ ] CI passes (backend + frontend)
- [ ] Open provider detail → Ask "What are the risk signals?" → get direct answer (no SQL)
- [ ] Ask "Compare to other providers in same state" → SQL generated and executed
- [ ] Dashboard chat (no NPI) → existing text-to-SQL behavior unchanged