### PR TITLE
feat(live): change speed slider to TPS control

### DIFF
--- a/frontend/src/pages/LiveMonitor.tsx
+++ b/frontend/src/pages/LiveMonitor.tsx
@@ -182,7 +182,7 @@ export function LiveMonitor() {
   const navigate = useNavigate();
   const esRef = useRef<EventSource | null>(null);
   const [running, setRunning] = useState(false);
-  const [speed, setSpeed] = useState(1.5);
+  const [speed, setSpeed] = useState(0.5);
   const [events, setEvents] = useState<LiveClaimEvent[]>([]);
   const [stats, setStats] = useState<LiveStats>({
     total: 0,
@@ -280,17 +280,17 @@ export function LiveMonitor() {
           )}
         </div>
         <div className="flex items-center gap-2">
-          <label className="text-xs text-slate-500 font-medium">Speed</label>
+          <label className="text-xs text-slate-500 font-medium">TPS</label>
           <input
             type="range"
-            min={0.5}
-            max={3}
-            step={0.5}
+            min={0.1}
+            max={2}
+            step={0.1}
             value={speed}
             onChange={(e) => setSpeed(Number(e.target.value))}
             className="w-24 accent-indigo-600"
           />
-          <span className="text-xs text-slate-600 font-mono w-8">{speed}s</span>
+          <span className="text-xs text-slate-600 font-mono w-12">~{Math.round(1 / speed)}/s</span>
           <button
             onClick={running ? stopStream : startStream}
             className={cn(

--- a/src/api/routes/live.py
+++ b/src/api/routes/live.py
@@ -63,7 +63,7 @@ _FEATURES_SQL = """SELECT * FROM provider_features WHERE npi = %s"""
 
 @router.get("/stream")
 async def stream_claims(
-    interval: float = Query(default=1.5, ge=0.5, le=5.0),
+    interval: float = Query(default=0.5, ge=0.1, le=2.0),
     limit: int = Query(default=0, ge=0),
 ):
     """Stream scored claims as Server-Sent Events.


### PR DESCRIPTION
## Summary

Changes the Live Monitor speed control from interval (0.5-3s) to TPS (1-10 events/sec).

- Backend: interval range `0.1-2.0s` (was `0.5-5.0s`)
- Frontend: slider shows `~N/s` instead of `Ns`, range 0.1-2.0
- Default: 0.5s interval (~2 TPS)

2 files, 7 lines changed. No new logic — just widened existing range.

## Test plan
- [ ] CI passes
- [ ] Slider shows TPS label and ~N/s display
- [ ] 10 TPS (0.1s) streams smoothly without lag