### PR TITLE
feat(live): persistent stream with TPS control and big numbers

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { lazy } from "react";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { AuthProvider } from "./contexts/AuthContext";
+import { LiveStreamProvider } from "./contexts/LiveStreamContext";
 import { ProtectedRoute } from "./components/ProtectedRoute";
 import { Layout } from "./components/Layout";
 import { Login } from "./pages/Login";
@@ -54,30 +55,32 @@ export default function App() {
   return (
     <BrowserRouter>
       <AuthProvider>
-        <Routes>
-          <Route path="/login" element={<Login />} />
-          <Route element={<ProtectedRoute />}>
-            <Route path="/" element={<Layout />}>
-              <Route index element={<Dashboard />} />
-              <Route path="simulate" element={<Simulate />} />
-              <Route path="providers" element={<Providers />} />
-              <Route path="providers/:npi" element={<ProviderDetail />} />
-              <Route path="claims" element={<Claims />} />
-              <Route path="claims/:caseId" element={<ClaimDetail />} />
-              <Route path="investigations" element={<Investigations />} />
-              <Route
-                path="investigations/:caseId"
-                element={<InvestigationDetail />}
-              />
-              <Route path="risk-map" element={<RiskMap />} />
-              <Route path="fairness" element={<Fairness />} />
-              <Route path="analytics" element={<Analytics />} />
-              <Route path="validation" element={<Validation />} />
-              <Route path="live" element={<LiveMonitor />} />
-              <Route path="data" element={<DataManagement />} />
+        <LiveStreamProvider>
+          <Routes>
+            <Route path="/login" element={<Login />} />
+            <Route element={<ProtectedRoute />}>
+              <Route path="/" element={<Layout />}>
+                <Route index element={<Dashboard />} />
+                <Route path="simulate" element={<Simulate />} />
+                <Route path="providers" element={<Providers />} />
+                <Route path="providers/:npi" element={<ProviderDetail />} />
+                <Route path="claims" element={<Claims />} />
+                <Route path="claims/:caseId" element={<ClaimDetail />} />
+                <Route path="investigations" element={<Investigations />} />
+                <Route
+                  path="investigations/:caseId"
+                  element={<InvestigationDetail />}
+                />
+                <Route path="risk-map" element={<RiskMap />} />
+                <Route path="fairness" element={<Fairness />} />
+                <Route path="analytics" element={<Analytics />} />
+                <Route path="validation" element={<Validation />} />
+                <Route path="live" element={<LiveMonitor />} />
+                <Route path="data" element={<DataManagement />} />
+              </Route>
             </Route>
-          </Route>
-        </Routes>
+          </Routes>
+        </LiveStreamProvider>
       </AuthProvider>
     </BrowserRouter>
   );

--- a/frontend/src/contexts/LiveStreamContext.tsx
+++ b/frontend/src/contexts/LiveStreamContext.tsx
@@ -1,0 +1,175 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import type { ReactNode } from "react";
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL ?? "";
+
+/* ── Types ──────────────────────────────────────────────────── */
+
+export interface LiveClaimEvent {
+  event_id: string;
+  timestamp: string;
+  npi: string;
+  provider_name: string;
+  state: string;
+  city: string;
+  hcpcs_code: string;
+  hcpcs_desc: string;
+  submitted_charge: number;
+  risk_score: number;
+  legitimacy_score: number;
+  case_label: "high_risk" | "review" | "stable";
+  anomaly_score: number | null;
+  signals: string[];
+  scoring_latency_ms: number;
+}
+
+export interface LiveStats {
+  total: number;
+  flagged: number;
+  totalLatency: number;
+}
+
+export type TpsPreset = 1 | 2 | 5 | 10;
+
+const TPS_TO_INTERVAL: Record<TpsPreset, number> = {
+  1: 1.0,
+  2: 0.5,
+  5: 0.2,
+  10: 0.1,
+};
+
+interface LiveStreamState {
+  running: boolean;
+  tps: TpsPreset;
+  events: LiveClaimEvent[];
+  stats: LiveStats;
+  stateDots: Map<string, LiveClaimEvent>;
+  start: () => void;
+  stop: () => void;
+  reset: () => void;
+  setTps: (tps: TpsPreset) => void;
+}
+
+const LiveStreamContext = createContext<LiveStreamState | null>(null);
+
+/* ── Provider ───────────────────────────────────────────────── */
+
+const MAX_FEED_EVENTS = 200;
+
+export function LiveStreamProvider({ children }: { children: ReactNode }) {
+  const esRef = useRef<EventSource | null>(null);
+  const [running, setRunning] = useState(false);
+  const [tps, setTpsState] = useState<TpsPreset>(2);
+  const [events, setEvents] = useState<LiveClaimEvent[]>([]);
+  const [stats, setStats] = useState<LiveStats>({
+    total: 0,
+    flagged: 0,
+    totalLatency: 0,
+  });
+  const [stateDots, setStateDots] = useState<Map<string, LiveClaimEvent>>(
+    new Map(),
+  );
+
+  const handleEvent = useCallback((evt: LiveClaimEvent) => {
+    setEvents((prev) => [evt, ...prev].slice(0, MAX_FEED_EVENTS));
+    setStats((prev) => ({
+      total: prev.total + 1,
+      flagged: prev.flagged + (evt.case_label === "high_risk" ? 1 : 0),
+      totalLatency: prev.totalLatency + evt.scoring_latency_ms,
+    }));
+    setStateDots((prev) => {
+      const next = new Map(prev);
+      next.set(evt.state, evt);
+      return next;
+    });
+  }, []);
+
+  const openConnection = useCallback(
+    (interval: number) => {
+      if (esRef.current) esRef.current.close();
+      const es = new EventSource(
+        `${API_BASE}/api/live/stream?interval=${interval}`,
+      );
+      es.onmessage = (e) => {
+        const data: LiveClaimEvent = JSON.parse(e.data);
+        handleEvent(data);
+      };
+      es.onerror = () => {
+        es.close();
+        esRef.current = null;
+        setRunning(false);
+      };
+      esRef.current = es;
+      setRunning(true);
+    },
+    [handleEvent],
+  );
+
+  const start = useCallback(() => {
+    openConnection(TPS_TO_INTERVAL[tps]);
+  }, [tps, openConnection]);
+
+  const stop = useCallback(() => {
+    esRef.current?.close();
+    esRef.current = null;
+    setRunning(false);
+  }, []);
+
+  const reset = useCallback(() => {
+    stop();
+    setEvents([]);
+    setStats({ total: 0, flagged: 0, totalLatency: 0 });
+    setStateDots(new Map());
+  }, [stop]);
+
+  const setTps = useCallback(
+    (newTps: TpsPreset) => {
+      setTpsState(newTps);
+      if (esRef.current) {
+        openConnection(TPS_TO_INTERVAL[newTps]);
+      }
+    },
+    [openConnection],
+  );
+
+  // Cleanup only on full app unmount (not navigation)
+  useEffect(() => {
+    return () => {
+      esRef.current?.close();
+    };
+  }, []);
+
+  return (
+    <LiveStreamContext.Provider
+      value={{
+        running,
+        tps,
+        events,
+        stats,
+        stateDots,
+        start,
+        stop,
+        reset,
+        setTps,
+      }}
+    >
+      {children}
+    </LiveStreamContext.Provider>
+  );
+}
+
+/* ── Hook ───────────────────────────────────────────────────── */
+
+export function useLiveStream(): LiveStreamState {
+  const ctx = useContext(LiveStreamContext);
+  if (!ctx)
+    throw new Error("useLiveStream must be used within LiveStreamProvider");
+  return ctx;
+}

--- a/frontend/src/pages/LiveMonitor.tsx
+++ b/frontend/src/pages/LiveMonitor.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { AnimatePresence, motion } from "motion/react";
 import {
@@ -20,37 +20,12 @@ import {
 } from "lucide-react";
 import { cn } from "../lib/utils";
 import { formatUSD } from "../lib/helpers";
+import { useLiveStream } from "../contexts/LiveStreamContext";
+import type { LiveClaimEvent, TpsPreset } from "../contexts/LiveStreamContext";
 
-const API_BASE = import.meta.env.DEV
-  ? ""
-  : import.meta.env.VITE_API_BASE_URL ?? "";
 const GEO_URL = "https://cdn.jsdelivr.net/npm/us-atlas@3/states-10m.json";
 
-/* ── Types ──────────────────────────────────────────────────── */
-
-interface LiveClaimEvent {
-  event_id: string;
-  timestamp: string;
-  npi: string;
-  provider_name: string;
-  state: string;
-  city: string;
-  hcpcs_code: string;
-  hcpcs_desc: string;
-  submitted_charge: number;
-  risk_score: number;
-  legitimacy_score: number;
-  case_label: "high_risk" | "review" | "stable";
-  anomaly_score: number | null;
-  signals: string[];
-  scoring_latency_ms: number;
-}
-
-interface LiveStats {
-  total: number;
-  flagged: number;
-  totalLatency: number;
-}
+const TPS_OPTIONS: TpsPreset[] = [1, 2, 5, 10];
 
 /* ── State centroids (lon, lat) for geoAlbersUsa projection ── */
 
@@ -180,76 +155,9 @@ function labelDot(label: string): string {
 
 export function LiveMonitor() {
   const navigate = useNavigate();
-  const esRef = useRef<EventSource | null>(null);
-  const [running, setRunning] = useState(false);
-  const [speed, setSpeed] = useState(1.5);
-  const [events, setEvents] = useState<LiveClaimEvent[]>([]);
-  const [stats, setStats] = useState<LiveStats>({
-    total: 0,
-    flagged: 0,
-    totalLatency: 0,
-  });
-  const [stateDots, setStateDots] = useState<Map<string, LiveClaimEvent>>(
-    new Map(),
-  );
+  const { running, tps, events, stats, stateDots, start, stop, reset, setTps } =
+    useLiveStream();
   const [feedExpanded, setFeedExpanded] = useState(false);
-
-  const handleEvent = useCallback((evt: LiveClaimEvent) => {
-    setEvents((prev) => [evt, ...prev].slice(0, 50));
-    setStats((prev) => ({
-      total: prev.total + 1,
-      flagged: prev.flagged + (evt.case_label === "high_risk" ? 1 : 0),
-      totalLatency: prev.totalLatency + evt.scoring_latency_ms,
-    }));
-    setStateDots((prev) => {
-      const next = new Map(prev);
-      next.set(evt.state, evt);
-      return next;
-    });
-  }, []);
-
-  const startStream = useCallback(() => {
-    if (esRef.current) esRef.current.close();
-    const es = new EventSource(`${API_BASE}/api/live/stream?interval=${speed}`);
-    es.onmessage = (e) => {
-      const data: LiveClaimEvent = JSON.parse(e.data);
-      handleEvent(data);
-    };
-    es.onerror = () => {
-      es.close();
-      setRunning(false);
-    };
-    esRef.current = es;
-    setRunning(true);
-  }, [speed, handleEvent]);
-
-  const stopStream = useCallback(() => {
-    esRef.current?.close();
-    esRef.current = null;
-    setRunning(false);
-  }, []);
-
-  const resetStream = useCallback(() => {
-    stopStream();
-    setEvents([]);
-    setStats({ total: 0, flagged: 0, totalLatency: 0 });
-    setStateDots(new Map());
-  }, [stopStream]);
-
-  // Restart stream when speed changes while running
-  useEffect(() => {
-    if (running) {
-      startStream();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [speed]);
-
-  // Cleanup on unmount
-  useEffect(() => {
-    return () => {
-      esRef.current?.close();
-    };
-  }, []);
 
   // Close modal on Escape
   useEffect(() => {
@@ -280,19 +188,25 @@ export function LiveMonitor() {
           )}
         </div>
         <div className="flex items-center gap-2">
-          <label className="text-xs text-slate-500 font-medium">Speed</label>
-          <input
-            type="range"
-            min={0.5}
-            max={3}
-            step={0.5}
-            value={speed}
-            onChange={(e) => setSpeed(Number(e.target.value))}
-            className="w-24 accent-indigo-600"
-          />
-          <span className="text-xs text-slate-600 font-mono w-8">{speed}s</span>
+          <span className="text-xs text-slate-500 font-medium">TPS</span>
+          <div className="flex rounded-lg border border-slate-200 overflow-hidden">
+            {TPS_OPTIONS.map((t) => (
+              <button
+                key={t}
+                onClick={() => setTps(t)}
+                className={cn(
+                  "px-2.5 py-1 text-xs font-bold transition-colors",
+                  tps === t
+                    ? "bg-indigo-600 text-white"
+                    : "bg-white text-slate-600 hover:bg-slate-50",
+                )}
+              >
+                {t}
+              </button>
+            ))}
+          </div>
           <button
-            onClick={running ? stopStream : startStream}
+            onClick={running ? stop : start}
             className={cn(
               "flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-semibold transition-colors",
               running
@@ -311,7 +225,7 @@ export function LiveMonitor() {
             )}
           </button>
           <button
-            onClick={resetStream}
+            onClick={reset}
             className="p-1.5 rounded-lg text-slate-400 hover:text-slate-700 hover:bg-slate-100 transition-colors"
             title="Reset"
           >
@@ -320,24 +234,24 @@ export function LiveMonitor() {
         </div>
       </div>
 
-      {/* Stats Bar */}
+      {/* Big Stats */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
-        <StatCard
-          label="Claims Processed"
+        <BigStat
+          label="Claims Scanned"
           value={stats.total.toLocaleString()}
-          icon={<Activity className="w-4 h-4 text-indigo-500" />}
-          color="text-slate-800"
+          icon={<Activity className="w-5 h-5 text-indigo-500" />}
+          color="text-slate-900"
         />
-        <StatCard
-          label="Flagged (High Risk)"
+        <BigStat
+          label="Flagged"
           value={stats.flagged.toLocaleString()}
-          icon={<ShieldAlert className="w-4 h-4 text-rose-500" />}
-          color={stats.flagged > 0 ? "text-rose-600" : "text-slate-800"}
+          icon={<ShieldAlert className="w-5 h-5 text-rose-500" />}
+          color={stats.flagged > 0 ? "text-rose-600" : "text-slate-900"}
         />
-        <StatCard
+        <BigStat
           label="Flag Rate"
           value={`${flagRate.toFixed(1)}%`}
-          icon={<TrendingUp className="w-4 h-4 text-amber-500" />}
+          icon={<TrendingUp className="w-5 h-5 text-amber-500" />}
           color={
             flagRate > 10
               ? "text-rose-600"
@@ -346,10 +260,10 @@ export function LiveMonitor() {
                 : "text-emerald-600"
           }
         />
-        <StatCard
+        <BigStat
           label="Avg Latency"
           value={`${avgLatency.toFixed(1)}ms`}
-          icon={<Zap className="w-4 h-4 text-emerald-500" />}
+          icon={<Zap className="w-5 h-5 text-emerald-500" />}
           color={
             avgLatency > 100
               ? "text-rose-600"
@@ -583,7 +497,7 @@ function FeedList({
   );
 }
 
-function StatCard({
+function BigStat({
   label,
   value,
   icon,
@@ -595,14 +509,21 @@ function StatCard({
   color: string;
 }) {
   return (
-    <div className="bg-white rounded-xl border border-slate-200 shadow-sm px-4 py-3 flex items-center gap-3">
-      <div className="p-2 rounded-lg bg-slate-50">{icon}</div>
-      <div>
-        <p className="text-xs font-bold text-slate-400 uppercase tracking-wider">
+    <div className="bg-white rounded-xl border border-slate-200 shadow-sm px-5 py-4">
+      <div className="flex items-center gap-2 mb-2">
+        <div className="p-1.5 rounded-lg bg-slate-50">{icon}</div>
+        <p className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">
           {label}
         </p>
-        <p className={cn("text-lg font-bold", color)}>{value}</p>
       </div>
+      <p
+        className={cn(
+          "text-4xl font-bold font-mono tabular-nums tracking-tight",
+          color,
+        )}
+      >
+        {value}
+      </p>
     </div>
   );
 }

--- a/src/api/routes/live.py
+++ b/src/api/routes/live.py
@@ -63,7 +63,7 @@ _FEATURES_SQL = """SELECT * FROM provider_features WHERE npi = %s"""
 
 @router.get("/stream")
 async def stream_claims(
-    interval: float = Query(default=1.5, ge=0.5, le=5.0),
+    interval: float = Query(default=0.5, ge=0.1, le=2.0),
     limit: int = Query(default=0, ge=0),
 ):
     """Stream scored claims as Server-Sent Events.


### PR DESCRIPTION
## Summary

Live Monitor stream now persists across page navigation with TPS preset controls and big dashboard-style stat numbers.

### What changed
- **LiveStreamContext** — SSE connection + state lives at app root, survives navigation
- **TPS buttons** (1, 2, 5, 10) replace slider — no reconnect storm
- **Big stat cards** — text-4xl mono tabular-nums counters
- **Backend** — interval range 0.1-2.0s (was 0.5-5.0s)
- **Persistence** — navigate away and back, stream still running, stats intact
- **Reset** — only on explicit button click

### Files
- `frontend/src/contexts/LiveStreamContext.tsx` (new)
- `frontend/src/pages/LiveMonitor.tsx` (rewritten)
- `frontend/src/App.tsx` (wrap with provider)
- `src/api/routes/live.py` (interval range)

## Test plan
- [x] CI passes
- [x] Start stream at 10 TPS, navigate to Providers, come back — stream still running
- [x] Big numbers tick up in real-time
- [x] Reset clears everything
- [x] TPS switch reconnects cleanly