### PR TITLE
feat(pipeline): add one-click synthetic data seeding with full recalibration

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6,7 +6,7 @@
 
 const API_BASE = import.meta.env.DEV
   ? ""
-  : import.meta.env.VITE_API_BASE_URL ?? "";
+  : (import.meta.env.VITE_API_BASE_URL ?? "");
 
 /* ── Auth token management ─────────────────────────────────── */
 
@@ -753,16 +753,20 @@ export async function uploadData(
 }
 
 export function triggerRecalibrate(): Promise<PipelineRunDetail> {
-  return request<PipelineRunDetail>("/api/ingest/runs", {
+  return request<PipelineRunDetail>("/api/ingest/recalibrate", {
     method: "POST",
-    body: { run_type: "recalibration", triggered_by: "admin_ui" },
   });
 }
 
 export function triggerRetrain(): Promise<PipelineRunDetail> {
-  return request<PipelineRunDetail>("/api/ingest/runs", {
+  return request<PipelineRunDetail>("/api/ingest/retrain", {
     method: "POST",
-    body: { run_type: "retrain_and_recalibrate", triggered_by: "admin_ui" },
+  });
+}
+
+export function seedSyntheticData(): Promise<PipelineRunDetail> {
+  return request<PipelineRunDetail>("/api/ingest/seed", {
+    method: "POST",
   });
 }
 

--- a/frontend/src/pages/DataManagement.tsx
+++ b/frontend/src/pages/DataManagement.tsx
@@ -12,18 +12,25 @@ import {
   ChevronRight,
   XCircle,
   Play,
+  FlaskConical,
 } from "lucide-react";
+import { Link } from "react-router-dom";
 import { cn } from "../lib/utils";
 import { useAuth } from "../contexts/AuthContext";
 import {
   uploadData,
   triggerRecalibrate,
   triggerRetrain,
+  seedSyntheticData,
   getPipelineRuns,
   getPipelineRun,
   getSourceVersions,
 } from "../lib/api";
-import type { SourceVersion, UploadResponse, PipelineRunDetail } from "../lib/api";
+import type {
+  SourceVersion,
+  UploadResponse,
+  PipelineRunDetail,
+} from "../lib/api";
 
 /* ── Helpers ───────────────────────────────────────────────── */
 
@@ -98,8 +105,18 @@ function DataSourcesSection({
   loading: boolean;
 }) {
   const fallback: SourceVersion[] = [
-    { source_type: "Part B Service", version: "—", uploaded_at: "", row_count: 0 },
-    { source_type: "Part B Provider", version: "—", uploaded_at: "", row_count: 0 },
+    {
+      source_type: "Part B Service",
+      version: "—",
+      uploaded_at: "",
+      row_count: 0,
+    },
+    {
+      source_type: "Part B Provider",
+      version: "—",
+      uploaded_at: "",
+      row_count: 0,
+    },
     { source_type: "Enrollment", version: "—", uploaded_at: "", row_count: 0 },
     { source_type: "Revocations", version: "—", uploaded_at: "", row_count: 0 },
   ];
@@ -107,7 +124,10 @@ function DataSourcesSection({
 
   return (
     <section aria-labelledby="sources-heading">
-      <h2 id="sources-heading" className="text-lg font-bold text-slate-800 mb-4">
+      <h2
+        id="sources-heading"
+        className="text-lg font-bold text-slate-800 mb-4"
+      >
         Data Sources
       </h2>
       {loading ? (
@@ -117,7 +137,9 @@ function DataSourcesSection({
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
           {display.map((src) => {
-            const color = src.uploaded_at ? freshnessColor(src.uploaded_at) : "red";
+            const color = src.uploaded_at
+              ? freshnessColor(src.uploaded_at)
+              : "red";
             const label = freshnessLabel(color);
             const cadence = SOURCE_CADENCE[src.source_type] ?? "Annual";
             return (
@@ -150,14 +172,19 @@ function DataSourcesSection({
                     {label}
                   </span>
                 </div>
-                <p className="font-semibold text-slate-800 text-sm">{src.source_type}</p>
+                <p className="font-semibold text-slate-800 text-sm">
+                  {src.source_type}
+                </p>
                 <p className="text-xs text-slate-500 mt-0.5">
-                  Version: <span className="font-medium">{src.version || "—"}</span>
+                  Version:{" "}
+                  <span className="font-medium">{src.version || "—"}</span>
                 </p>
                 <p className="text-xs text-slate-500">
                   Uploaded:{" "}
                   <span className="font-medium">
-                    {src.uploaded_at ? new Date(src.uploaded_at).toLocaleDateString() : "—"}
+                    {src.uploaded_at
+                      ? new Date(src.uploaded_at).toLocaleDateString()
+                      : "—"}
                   </span>
                 </p>
                 <p className="text-xs text-slate-500">
@@ -307,12 +334,14 @@ function UploadSection({ onUploadComplete }: { onUploadComplete: () => void }) {
         >
           <Upload className="w-8 h-8 mx-auto mb-2 text-slate-400" />
           {file ? (
-            <p className="text-sm font-semibold text-emerald-700">{file.name}</p>
+            <p className="text-sm font-semibold text-emerald-700">
+              {file.name}
+            </p>
           ) : (
             <>
               <p className="text-sm text-slate-600">
-                Drag &amp; drop a <span className="font-semibold">.csv</span> file here, or
-                click to browse
+                Drag &amp; drop a <span className="font-semibold">.csv</span>{" "}
+                file here, or click to browse
               </p>
               <p className="text-xs text-slate-400 mt-1">Accepts .csv only</p>
             </>
@@ -354,7 +383,8 @@ function UploadSection({ onUploadComplete }: { onUploadComplete: () => void }) {
           <div className="bg-emerald-50 border border-emerald-200 rounded-lg px-4 py-3 text-sm">
             <p className="font-semibold text-emerald-800">Upload successful</p>
             <p className="text-emerald-700 text-xs mt-1">
-              {result.row_count.toLocaleString()} rows · Version {result.version}
+              {result.row_count.toLocaleString()} rows · Version{" "}
+              {result.version}
               {result.duplicate_detected && " · ⚠ Duplicate detected"}
             </p>
             {result.warnings.length > 0 && (
@@ -429,7 +459,9 @@ function RecalibrateSection({
       const r = await triggerRecalibrate();
       onStart(r.id);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to start recalibration");
+      setError(
+        err instanceof Error ? err.message : "Failed to start recalibration",
+      );
     } finally {
       setTriggering(false);
     }
@@ -449,14 +481,18 @@ function RecalibrateSection({
   }
 
   // Build ordered stage map
-  const stageMap: Record<string, PipelineRunDetail["stage_results"][number]> = {};
+  const stageMap: Record<string, PipelineRunDetail["stage_results"][number]> =
+    {};
   (run?.stage_results ?? []).forEach((s) => {
     stageMap[s.stage] = s;
   });
 
   return (
     <section aria-labelledby="recalibrate-heading">
-      <h2 id="recalibrate-heading" className="text-lg font-bold text-slate-800 mb-4">
+      <h2
+        id="recalibrate-heading"
+        className="text-lg font-bold text-slate-800 mb-4"
+      >
         Recalibrate Scores
       </h2>
       <div className="bg-white rounded-xl border border-slate-200 shadow-sm p-6 space-y-5">
@@ -551,7 +587,9 @@ function RecalibrateSection({
                     </span>
                   )}
                   {stageStatus === "pending" && (
-                    <span className="text-xs text-slate-300 shrink-0">pending</span>
+                    <span className="text-xs text-slate-300 shrink-0">
+                      pending
+                    </span>
                   )}
                 </div>
               );
@@ -577,8 +615,12 @@ function RecalibrateSection({
               <div className="flex items-start gap-2 bg-rose-50 border border-rose-200 rounded-lg px-4 py-3 mt-2">
                 <AlertCircle className="w-4 h-4 text-rose-500 shrink-0 mt-0.5" />
                 <div className="flex-1">
-                  <p className="text-sm font-semibold text-rose-800">Pipeline failed</p>
-                  <p className="text-xs text-rose-700 mt-0.5">{run.error_message}</p>
+                  <p className="text-sm font-semibold text-rose-800">
+                    Pipeline failed
+                  </p>
+                  <p className="text-xs text-rose-700 mt-0.5">
+                    {run.error_message}
+                  </p>
                 </div>
                 <button
                   onClick={handleRecalibrate}
@@ -628,7 +670,10 @@ function RunHistorySection() {
 
   return (
     <section aria-labelledby="history-heading">
-      <h2 id="history-heading" className="text-lg font-bold text-slate-800 mb-4">
+      <h2
+        id="history-heading"
+        className="text-lg font-bold text-slate-800 mb-4"
+      >
         Run History
       </h2>
       <div className="bg-white rounded-xl border border-slate-200 shadow-sm overflow-hidden">
@@ -643,17 +688,23 @@ function RunHistorySection() {
             <table className="min-w-full divide-y divide-slate-200">
               <thead className="bg-slate-50">
                 <tr>
-                  {["Run ID", "Type", "Status", "Triggered By", "Started", "Completed", ""].map(
-                    (h) => (
-                      <th
-                        key={h}
-                        scope="col"
-                        className="px-4 py-3 text-left text-xs font-bold text-slate-500 uppercase tracking-wider"
-                      >
-                        {h}
-                      </th>
-                    ),
-                  )}
+                  {[
+                    "Run ID",
+                    "Type",
+                    "Status",
+                    "Triggered By",
+                    "Started",
+                    "Completed",
+                    "",
+                  ].map((h) => (
+                    <th
+                      key={h}
+                      scope="col"
+                      className="px-4 py-3 text-left text-xs font-bold text-slate-500 uppercase tracking-wider"
+                    >
+                      {h}
+                    </th>
+                  ))}
                 </tr>
               </thead>
               <tbody className="divide-y divide-slate-100">
@@ -663,7 +714,9 @@ function RunHistorySection() {
                       <td className="px-4 py-3 text-sm font-mono text-slate-700">
                         #{run.id}
                       </td>
-                      <td className="px-4 py-3 text-xs text-slate-700">{run.run_type}</td>
+                      <td className="px-4 py-3 text-xs text-slate-700">
+                        {run.run_type}
+                      </td>
                       <td className="px-4 py-3">
                         <span
                           className={cn(
@@ -721,15 +774,18 @@ function RunHistorySection() {
                                     {STAGE_NAMES[s.stage] ?? s.stage}
                                   </p>
                                   {s.error && (
-                                    <p className="text-xs text-rose-600">{s.error}</p>
-                                  )}
-                                  {s.metrics && Object.keys(s.metrics).length > 0 && (
-                                    <p className="text-xs text-slate-500">
-                                      {Object.entries(s.metrics)
-                                        .map(([k, v]) => `${k}: ${v}`)
-                                        .join(" · ")}
+                                    <p className="text-xs text-rose-600">
+                                      {s.error}
                                     </p>
                                   )}
+                                  {s.metrics &&
+                                    Object.keys(s.metrics).length > 0 && (
+                                      <p className="text-xs text-slate-500">
+                                        {Object.entries(s.metrics)
+                                          .map(([k, v]) => `${k}: ${v}`)
+                                          .join(" · ")}
+                                      </p>
+                                    )}
                                 </div>
                                 <span className="text-xs text-slate-400 shrink-0">
                                   {formatDuration(s.duration_s)}
@@ -744,6 +800,83 @@ function RunHistorySection() {
                 ))}
               </tbody>
             </table>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+/* ── Seed Synthetic Data ───────────────────────────────────── */
+
+function SeedSection({
+  onStart,
+  isRunning,
+}: {
+  onStart: (runId: number) => void;
+  isRunning: boolean;
+}) {
+  const [seeding, setSeeding] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  async function handleSeed() {
+    setSeeding(true);
+    setError(null);
+    try {
+      const r = await seedSyntheticData();
+      onStart(r.id);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to start synthetic seed",
+      );
+    } finally {
+      setSeeding(false);
+    }
+  }
+
+  return (
+    <section aria-labelledby="seed-heading">
+      <h2 id="seed-heading" className="text-lg font-bold text-slate-800 mb-4">
+        Demo Mode
+      </h2>
+      <div className="bg-white rounded-xl border border-slate-200 shadow-sm p-6">
+        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+          <div className="flex items-start gap-3">
+            <FlaskConical className="w-8 h-8 text-indigo-500 shrink-0 mt-0.5" />
+            <div>
+              <p className="text-sm font-semibold text-slate-800">
+                Seed Synthetic Data
+              </p>
+              <p className="text-xs text-slate-500 mt-0.5">
+                Generate 250 synthetic providers (4,250 service lines) and run
+                full recalibration pipeline. After completion, visit{" "}
+                <Link
+                  to="/live"
+                  className="text-indigo-600 hover:text-indigo-800 font-medium"
+                >
+                  Live Monitor
+                </Link>{" "}
+                to see real-time scoring.
+              </p>
+            </div>
+          </div>
+          <button
+            onClick={handleSeed}
+            disabled={seeding || isRunning}
+            className="flex items-center gap-2 px-5 py-2.5 bg-indigo-600 text-white text-sm font-semibold rounded-lg hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors shrink-0"
+          >
+            {seeding ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : (
+              <FlaskConical className="w-4 h-4" />
+            )}
+            {seeding ? "Starting…" : "Seed Synthetic Data"}
+          </button>
+        </div>
+        {error && (
+          <div className="mt-3 flex items-start gap-2 bg-rose-50 border border-rose-200 rounded-lg px-4 py-3">
+            <AlertCircle className="w-4 h-4 text-rose-500 shrink-0 mt-0.5" />
+            <p className="text-sm text-rose-700">{error}</p>
           </div>
         )}
       </div>
@@ -777,7 +910,9 @@ export function DataManagement() {
       <div className="flex flex-col items-center justify-center py-24 gap-4">
         <AlertCircle className="w-12 h-12 text-rose-400" />
         <h1 className="text-2xl font-bold text-slate-800">Access Denied</h1>
-        <p className="text-slate-500">This page is only accessible to administrators.</p>
+        <p className="text-slate-500">
+          This page is only accessible to administrators.
+        </p>
       </div>
     );
   }
@@ -791,6 +926,7 @@ export function DataManagement() {
         </p>
       </div>
       <DataSourcesSection sources={sources} loading={sourcesLoading} />
+      <SeedSection onStart={setActiveRunId} isRunning={activeRunId != null} />
       <UploadSection onUploadComplete={loadSources} />
       <RecalibrateSection activeRunId={activeRunId} onStart={setActiveRunId} />
       <RunHistorySection />

--- a/frontend/src/pages/__tests__/DataManagement.test.tsx
+++ b/frontend/src/pages/__tests__/DataManagement.test.tsx
@@ -10,6 +10,7 @@ import {
   uploadData,
   triggerRecalibrate,
   triggerRetrain,
+  seedSyntheticData,
 } from "../../lib/api";
 
 /* ── Auth mock ─────────────────────────────────────────────── */
@@ -29,6 +30,7 @@ vi.mock("../../lib/api", () => ({
   uploadData: vi.fn(),
   triggerRecalibrate: vi.fn(),
   triggerRetrain: vi.fn(),
+  seedSyntheticData: vi.fn(),
 }));
 
 /* ── Shared fixtures ───────────────────────────────────────── */
@@ -151,7 +153,9 @@ describe("DataManagement", () => {
     renderPage();
     expect(screen.getByText("Data Management")).toBeInTheDocument();
     expect(
-      screen.getByText("Upload CMS data, trigger recalibration, and monitor pipeline runs."),
+      screen.getByText(
+        "Upload CMS data, trigger recalibration, and monitor pipeline runs.",
+      ),
     ).toBeInTheDocument();
   });
 
@@ -195,7 +199,12 @@ describe("DataManagement", () => {
 
   it("shows Stale badge for sources with no uploaded_at", async () => {
     vi.mocked(getSourceVersions).mockResolvedValue([
-      { source_type: "Part B Service", version: "—", uploaded_at: "", row_count: 0 },
+      {
+        source_type: "Part B Service",
+        version: "—",
+        uploaded_at: "",
+        row_count: 0,
+      },
     ]);
     renderPage();
     await waitFor(() => {
@@ -261,7 +270,9 @@ describe("DataManagement", () => {
 
     // Simulate file selection via the hidden input
     const fileInput = screen.getByLabelText("File input");
-    const mockFile = new File(["col1,col2\n1,2"], "data.csv", { type: "text/csv" });
+    const mockFile = new File(["col1,col2\n1,2"], "data.csv", {
+      type: "text/csv",
+    });
     await user.upload(fileInput, mockFile);
 
     // Now the upload button should be enabled
@@ -282,7 +293,9 @@ describe("DataManagement", () => {
   });
 
   it("shows upload error message on failure", async () => {
-    vi.mocked(uploadData).mockRejectedValue(new Error("Server error: invalid file"));
+    vi.mocked(uploadData).mockRejectedValue(
+      new Error("Server error: invalid file"),
+    );
 
     const user = userEvent.setup();
     renderPage();
@@ -291,7 +304,9 @@ describe("DataManagement", () => {
     await user.type(versionInput, "2025");
 
     const fileInput = screen.getByLabelText("File input");
-    const mockFile = new File(["col1,col2\n1,2"], "data.csv", { type: "text/csv" });
+    const mockFile = new File(["col1,col2\n1,2"], "data.csv", {
+      type: "text/csv",
+    });
     await user.upload(fileInput, mockFile);
 
     const uploadBtn = screen.getByRole("button", { name: /^Upload$/ });
@@ -319,7 +334,9 @@ describe("DataManagement", () => {
     await user.type(versionInput, "Q1-2025");
 
     const fileInput = screen.getByLabelText("File input");
-    const mockFile = new File(["npi\n1234"], "enroll.csv", { type: "text/csv" });
+    const mockFile = new File(["npi\n1234"], "enroll.csv", {
+      type: "text/csv",
+    });
     await user.upload(fileInput, mockFile);
 
     await user.click(screen.getByRole("button", { name: /^Upload$/ }));
@@ -327,7 +344,9 @@ describe("DataManagement", () => {
     await waitFor(() => {
       expect(screen.getByText(/Duplicate detected/)).toBeInTheDocument();
     });
-    expect(screen.getByText("Column 'npi' has 3 null values")).toBeInTheDocument();
+    expect(
+      screen.getByText("Column 'npi' has 3 null values"),
+    ).toBeInTheDocument();
   });
 
   it("triggers recalibration after upload when auto-recalibrate is checked", async () => {
@@ -347,7 +366,10 @@ describe("DataManagement", () => {
     await user.type(screen.getByLabelText("Version"), "2025");
 
     const fileInput = screen.getByLabelText("File input");
-    await user.upload(fileInput, new File(["a,b"], "data.csv", { type: "text/csv" }));
+    await user.upload(
+      fileInput,
+      new File(["a,b"], "data.csv", { type: "text/csv" }),
+    );
 
     await user.click(screen.getByRole("button", { name: /^Upload$/ }));
 
@@ -360,24 +382,41 @@ describe("DataManagement", () => {
 
   it("shows Recalibrate Scores section", () => {
     renderPage();
-    expect(screen.getByRole("heading", { name: "Recalibrate Scores" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Recalibrate Scores" }),
+    ).toBeInTheDocument();
   });
 
   it("shows Recalibrate Scores and Retrain Models buttons", () => {
     renderPage();
-    expect(screen.getByRole("button", { name: /Recalibrate Scores/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Retrain Models/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Recalibrate Scores/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Retrain Models/i }),
+    ).toBeInTheDocument();
   });
 
   it("triggers recalibration and shows run panel", async () => {
-    const runningRun = { ...mockRun, id: 99, status: "running", progress_pct: 20 };
+    const runningRun = {
+      ...mockRun,
+      id: 99,
+      status: "running",
+      progress_pct: 20,
+    };
     vi.mocked(triggerRecalibrate).mockResolvedValue(runningRun);
-    vi.mocked(getPipelineRun).mockResolvedValue({ ...runningRun, status: "completed", progress_pct: 100 });
+    vi.mocked(getPipelineRun).mockResolvedValue({
+      ...runningRun,
+      status: "completed",
+      progress_pct: 100,
+    });
 
     const user = userEvent.setup();
     renderPage();
 
-    await user.click(screen.getByRole("button", { name: /Recalibrate Scores/i }));
+    await user.click(
+      screen.getByRole("button", { name: /Recalibrate Scores/i }),
+    );
     await waitFor(() => {
       expect(vi.mocked(triggerRecalibrate)).toHaveBeenCalledOnce();
     });
@@ -403,12 +442,16 @@ describe("DataManagement", () => {
   });
 
   it("shows error when recalibration trigger fails", async () => {
-    vi.mocked(triggerRecalibrate).mockRejectedValue(new Error("Service unavailable"));
+    vi.mocked(triggerRecalibrate).mockRejectedValue(
+      new Error("Service unavailable"),
+    );
 
     const user = userEvent.setup();
     renderPage();
 
-    await user.click(screen.getByRole("button", { name: /Recalibrate Scores/i }));
+    await user.click(
+      screen.getByRole("button", { name: /Recalibrate Scores/i }),
+    );
 
     await waitFor(() => {
       expect(screen.getByText("Service unavailable")).toBeInTheDocument();
@@ -456,7 +499,9 @@ describe("DataManagement", () => {
   it("shows Details button for runs with stage results", async () => {
     renderPage();
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: /Details/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /Details/i }),
+      ).toBeInTheDocument();
     });
   });
 
@@ -465,7 +510,9 @@ describe("DataManagement", () => {
     renderPage();
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: /Details/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /Details/i }),
+      ).toBeInTheDocument();
     });
 
     await user.click(screen.getByRole("button", { name: /Details/i }));
@@ -481,7 +528,9 @@ describe("DataManagement", () => {
     renderPage();
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: /Details/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /Details/i }),
+      ).toBeInTheDocument();
     });
 
     const detailsBtn = screen.getByRole("button", { name: /Details/i });
@@ -503,7 +552,9 @@ describe("DataManagement", () => {
     renderPage();
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: /Details/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /Details/i }),
+      ).toBeInTheDocument();
     });
 
     await user.click(screen.getByRole("button", { name: /Details/i }));
@@ -540,7 +591,9 @@ describe("DataManagement", () => {
     const user = userEvent.setup();
     renderPage();
 
-    await user.click(screen.getByRole("button", { name: /Recalibrate Scores/i }));
+    await user.click(
+      screen.getByRole("button", { name: /Recalibrate Scores/i }),
+    );
 
     await waitFor(() => {
       // The run panel header should appear
@@ -552,14 +605,21 @@ describe("DataManagement", () => {
   });
 
   it("shows progress bar after run is triggered", async () => {
-    const completedRun = { ...mockRun, id: 55, status: "completed", progress_pct: 100 };
+    const completedRun = {
+      ...mockRun,
+      id: 55,
+      status: "completed",
+      progress_pct: 100,
+    };
     vi.mocked(triggerRecalibrate).mockResolvedValue(completedRun);
     vi.mocked(getPipelineRun).mockResolvedValue(completedRun);
 
     const user = userEvent.setup();
     renderPage();
 
-    await user.click(screen.getByRole("button", { name: /Recalibrate Scores/i }));
+    await user.click(
+      screen.getByRole("button", { name: /Recalibrate Scores/i }),
+    );
 
     await waitFor(() => {
       expect(screen.getByText("Overall progress")).toBeInTheDocument();
@@ -581,12 +641,75 @@ describe("DataManagement", () => {
     const user = userEvent.setup();
     renderPage();
 
-    await user.click(screen.getByRole("button", { name: /Recalibrate Scores/i }));
+    await user.click(
+      screen.getByRole("button", { name: /Recalibrate Scores/i }),
+    );
 
     await waitFor(() => {
       expect(screen.getByText("Pipeline failed")).toBeInTheDocument();
     });
     expect(screen.getByText("Database connection lost")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Retry/i })).toBeInTheDocument();
+  });
+
+  /* ── Seed Synthetic Data section ────────────────────────── */
+
+  it("shows Demo Mode section with seed button", () => {
+    renderPage();
+    expect(
+      screen.getByRole("heading", { name: "Demo Mode" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Seed Synthetic Data/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("triggers seed and starts polling when clicked", async () => {
+    const seedRun = {
+      ...mockRun,
+      id: 77,
+      run_type: "seed_synthetic",
+      status: "running",
+      progress_pct: 0,
+    };
+    vi.mocked(seedSyntheticData).mockResolvedValue(seedRun);
+    vi.mocked(getPipelineRun).mockResolvedValue({
+      ...seedRun,
+      status: "completed",
+      progress_pct: 100,
+    });
+
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(
+      screen.getByRole("button", { name: /Seed Synthetic Data/i }),
+    );
+
+    await waitFor(() => {
+      expect(vi.mocked(seedSyntheticData)).toHaveBeenCalledOnce();
+    });
+
+    // Should poll getPipelineRun with the returned run id
+    await waitFor(() => {
+      expect(vi.mocked(getPipelineRun)).toHaveBeenCalledWith(77);
+    });
+  });
+
+  it("shows error when seed trigger fails", async () => {
+    vi.mocked(seedSyntheticData).mockRejectedValue(
+      new Error("Pipeline already running"),
+    );
+
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(
+      screen.getByRole("button", { name: /Seed Synthetic Data/i }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Pipeline already running")).toBeInTheDocument();
+    });
   });
 });

--- a/scripts/generate_synthetic_data.py
+++ b/scripts/generate_synthetic_data.py
@@ -1,0 +1,90 @@
+"""Generate synthetic CMS data to local CSV files.
+
+Thin CLI wrapper around :mod:`src.pipeline.synthetic`.
+
+Usage::
+
+    uv run python scripts/generate_synthetic_data.py
+"""
+
+from __future__ import annotations
+
+import csv
+from collections import Counter
+from pathlib import Path
+
+from src.pipeline.synthetic import (
+    SEED,
+    SPECIALTIES,
+    Archetype,
+    SyntheticDataset,
+    generate_all,
+)
+
+OUTPUT_DIR = Path(__file__).resolve().parents[1] / "data" / "synthetic"
+
+
+def write_csv(rows: list[dict[str, str]], path: Path) -> int:
+    if not rows:
+        return 0
+    fieldnames = list(rows[0].keys())
+    with open(path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+    return len(rows)
+
+
+def print_summary(ds: SyntheticDataset, counts: dict[str, int]) -> None:
+    arch_counts = Counter(p.archetype for p in ds.providers)
+    n = len(ds.providers)
+    n_stable = arch_counts[Archetype.STABLE]
+    n_review = (
+        arch_counts[Archetype.REVIEW_MILD]
+        + arch_counts[Archetype.REVIEW_MID]
+        + arch_counts[Archetype.NOT_ENROLLED]
+    )
+    n_high = arch_counts[Archetype.HIGH_RISK_Z] + arch_counts[Archetype.HIGH_RISK_REVOKED]
+
+    print("\n=== Synthetic CMS Data Generator ===")
+    print(f"Seed: {SEED}")
+    print(f"\nFiles written to {OUTPUT_DIR}/:")
+    print(f"  part_b_service_synthetic.csv    {counts['service']:,} rows")
+    print(f"  part_b_provider_synthetic.csv   {counts['provider']:,} rows")
+    print(f"  enrollment_synthetic.csv        {counts['enrollment']:,} rows")
+    print(f"  revocations_synthetic.csv       {counts['revocations']:,} rows")
+
+    print("\nProvider distribution (predicted labels):")
+    print(f"  stable      {n_stable:>3} providers  ({n_stable / n * 100:.1f}%)")
+    print(f"  review      {n_review:>3} providers  ({n_review / n * 100:.1f}%)")
+    print(f"  high_risk   {n_high:>3} providers  ({n_high / n * 100:.1f}%)")
+    print(f"    z-score only:      {arch_counts[Archetype.HIGH_RISK_Z]}")
+    print(f"    revoked/unenrolled: {arch_counts[Archetype.HIGH_RISK_REVOKED]}")
+
+    print("\nPeer group coverage:")
+    for spec in SPECIALTIES:
+        print(f"  {spec['type']:<45} {len(spec['codes'])} codes x {spec['count']} providers")
+
+    print("\nUpload commands:")
+    print("  POST /api/ingest/upload  source_type=part_b_service   version=synthetic_2023")
+    print("  POST /api/ingest/upload  source_type=part_b_provider  version=synthetic_2023")
+    print("  POST /api/ingest/upload  source_type=enrollment       version=synthetic_q4_2025")
+    print("  POST /api/ingest/upload  source_type=revocations      version=synthetic_q1_2026")
+    print()
+
+
+def main() -> None:
+    ds = generate_all()
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    counts = {
+        "service": write_csv(ds.service_rows, OUTPUT_DIR / "part_b_service_synthetic.csv"),
+        "provider": write_csv(ds.provider_rows, OUTPUT_DIR / "part_b_provider_synthetic.csv"),
+        "enrollment": write_csv(ds.enrollment_rows, OUTPUT_DIR / "enrollment_synthetic.csv"),
+        "revocations": write_csv(ds.revocation_rows, OUTPUT_DIR / "revocations_synthetic.csv"),
+    }
+    print_summary(ds, counts)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/api/routes/ingest.py
+++ b/src/api/routes/ingest.py
@@ -55,6 +55,7 @@ from src.api.schemas import (
 from src.pipeline.column_maps import SOURCE_TYPES
 from src.pipeline.orchestrator import recalibrate, retrain_and_recalibrate
 from src.pipeline.raw_loader import LoadResult, load_raw_csv
+from src.pipeline.synthetic import SYNTHETIC_VERSIONS, generate_all
 
 logger = logging.getLogger(__name__)
 
@@ -286,6 +287,162 @@ async def trigger_retrain(
         id=run_id,
         run_type="retrain_and_recalibrate",
         status="pending",
+        triggered_by=user.username,
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST /ingest/seed — generate synthetic data + recalibrate (admin only)
+# ---------------------------------------------------------------------------
+
+
+def _seed_synthetic_sync(run_id: int, db_url: str) -> None:
+    """Generate synthetic CSVs, load into raw tables, then run recalibration.
+
+    Runs synchronously — designed to be called via ``asyncio.to_thread``.
+    """
+    import csv
+    import json
+
+    from src.pipeline.orchestrator import _run_recalibrate_sync, update_stage
+
+    with psycopg.connect(db_url) as conn:
+        # --- Stage: data_generation ---
+        update_stage(
+            conn,
+            run_id,
+            "data_generation",
+            "running",
+            {},
+            progress_pct=0,
+            stage_results=[],
+        )
+        ds = generate_all()
+        gen_metrics = {
+            "providers": len(ds.providers),
+            "service_rows": len(ds.service_rows),
+            "provider_rows": len(ds.provider_rows),
+            "enrollment_rows": len(ds.enrollment_rows),
+            "revocation_rows": len(ds.revocation_rows),
+        }
+        stage_records: list[dict[str, Any]] = [
+            {"stage": "data_generation", "status": "completed", "metrics": gen_metrics},
+        ]
+        update_stage(
+            conn,
+            run_id,
+            "data_generation",
+            "running",
+            gen_metrics,
+            progress_pct=5,
+            stage_results=stage_records,
+        )
+
+        # --- Stage: data_loading ---
+        update_stage(
+            conn,
+            run_id,
+            "data_loading",
+            "running",
+            {},
+            progress_pct=5,
+            stage_results=stage_records,
+        )
+        sources = [
+            ("part_b_service", ds.service_rows, SYNTHETIC_VERSIONS["part_b_service"]),
+            ("part_b_provider", ds.provider_rows, SYNTHETIC_VERSIONS["part_b_provider"]),
+            ("enrollment", ds.enrollment_rows, SYNTHETIC_VERSIONS["enrollment"]),
+            ("revocations", ds.revocation_rows, SYNTHETIC_VERSIONS["revocations"]),
+        ]
+        load_metrics: dict[str, Any] = {}
+        for source_type, rows, version in sources:
+            if not rows:
+                continue
+            # Write to temp CSV
+            tmp = tempfile.NamedTemporaryFile(suffix=".csv", delete=False, mode="w", newline="")
+            writer = csv.DictWriter(tmp, fieldnames=list(rows[0].keys()))
+            writer.writeheader()
+            writer.writerows(rows)
+            tmp.close()
+            result = load_raw_csv(Path(tmp.name), source_type, version, conn, "seed_synthetic")
+            Path(tmp.name).unlink(missing_ok=True)
+            load_metrics[source_type] = result.row_count
+
+        stage_records.append(
+            {"stage": "data_loading", "status": "completed", "metrics": load_metrics},
+        )
+        update_stage(
+            conn,
+            run_id,
+            "data_loading",
+            "running",
+            load_metrics,
+            progress_pct=20,
+            stage_results=stage_records,
+        )
+
+        # Store source versions on the run record
+        conn.execute(
+            "UPDATE pipeline_runs SET source_versions = %s::jsonb WHERE id = %s",
+            (json.dumps(SYNTHETIC_VERSIONS), run_id),
+        )
+        conn.commit()
+
+    # --- Stages 1-6: recalibration pipeline ---
+    _run_recalibrate_sync(run_id, db_url)
+
+
+async def _seed_synthetic_background(run_id: int, db_url: str) -> None:
+    """Async wrapper for the seed-synthetic background task."""
+    try:
+        await asyncio.to_thread(_seed_synthetic_sync, run_id, db_url)
+    except Exception as exc:
+        logger.exception("[%s] Seed synthetic pipeline failed", run_id)
+        try:
+            with psycopg.connect(db_url) as conn:
+                conn.execute(
+                    "UPDATE pipeline_runs SET status='failed', error_message=%s, "
+                    "completed_at=NOW() WHERE id=%s",
+                    (str(exc), run_id),
+                )
+                conn.commit()
+        except Exception:
+            logger.exception("[%s] Failed to update run status after seed failure", run_id)
+
+
+@router.post("/seed", response_model=PipelineRunDetail, status_code=202)
+async def seed_synthetic_data(
+    background_tasks: BackgroundTasks,
+    user: UserResponse = Depends(require_admin),
+    conn: AsyncConnection = Depends(get_db),
+) -> PipelineRunDetail:
+    """Generate synthetic CMS data and run full recalibration pipeline.
+
+    Creates 250 synthetic providers across 4 specialties, loads them into
+    the raw tables, and triggers a complete 6-stage recalibration. Progress
+    is tracked in ``pipeline_runs`` and can be polled via
+    ``GET /ingest/runs/{id}``.
+    """
+    await _assert_no_running_pipeline(conn)
+
+    cur = await conn.execute(
+        "INSERT INTO pipeline_runs (run_type, status, triggered_by, started_at) "
+        "VALUES (%s, 'running', %s, NOW()) RETURNING id",
+        ("seed_synthetic", user.username),
+    )
+    run_row = await cur.fetchone()
+    if run_row is None:
+        raise HTTPException(status_code=500, detail="Failed to create pipeline run record")
+    run_id: int = int(run_row[0])
+    await conn.commit()
+
+    background_tasks.add_task(_seed_synthetic_background, run_id, DATABASE_URL)
+    logger.info("Seed synthetic run %d triggered by %s", run_id, user.username)
+
+    return PipelineRunDetail(
+        id=run_id,
+        run_type="seed_synthetic",
+        status="running",
         triggered_by=user.username,
     )
 

--- a/src/pipeline/synthetic.py
+++ b/src/pipeline/synthetic.py
@@ -1,0 +1,587 @@
+"""Synthetic CMS data generation — reusable library.
+
+Generates 4 sets of CMS-formatted rows (part_b_service, part_b_provider,
+enrollment, revocations) with vendor column names.  Designed to produce a
+meaningful distribution of high_risk, review, and stable labels after
+the ETL recalibration pipeline runs.
+
+Used by ``scripts/generate_synthetic_data.py`` (CLI) and
+``POST /api/ingest/seed`` (server-side one-click seeding).
+"""
+
+from __future__ import annotations
+
+import random
+import statistics
+from collections import defaultdict
+from dataclasses import dataclass
+from enum import StrEnum
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+SEED = 42
+
+# ---------------------------------------------------------------------------
+# Archetypes
+# ---------------------------------------------------------------------------
+
+
+class Archetype(StrEnum):
+    STABLE = "stable"
+    REVIEW_MILD = "review_mild"
+    REVIEW_MID = "review_mid"
+    HIGH_RISK_Z = "high_risk_z"
+    HIGH_RISK_REVOKED = "high_risk_revoked"
+    NOT_ENROLLED = "not_enrolled"
+
+
+# Z-score targets per archetype per dimension (volume, intensity, charge, payment)
+# None = draw from baseline (near-zero z).
+Z_TARGETS: dict[Archetype, tuple[float | None, ...]] = {
+    Archetype.STABLE: (None, None, None, None),
+    Archetype.REVIEW_MILD: (2.0, None, None, None),
+    Archetype.REVIEW_MID: (3.0, 3.0, None, None),
+    Archetype.HIGH_RISK_Z: (5.0, 5.0, 5.0, 5.0),
+    Archetype.HIGH_RISK_REVOKED: (3.0, 2.0, None, None),
+    Archetype.NOT_ENROLLED: (2.0, None, None, None),
+}
+
+# ---------------------------------------------------------------------------
+# Specialties and HCPCS pools
+# ---------------------------------------------------------------------------
+
+SPECIALTIES: list[dict] = [
+    {
+        "type": "Internal Medicine",
+        "count": 70,
+        "codes": [
+            ("99213", "Office/outpatient visit, est, 15 min"),
+            ("99214", "Office/outpatient visit, est, 25 min"),
+            ("99215", "Office/outpatient visit, est, 40 min"),
+            ("99203", "Office/outpatient visit, new, 30 min"),
+            ("99204", "Office/outpatient visit, new, 45 min"),
+            ("99205", "Office/outpatient visit, new, 60 min"),
+            ("99211", "Office/outpatient visit, est, 5 min"),
+            ("99212", "Office/outpatient visit, est, 10 min"),
+            ("36415", "Collection of venous blood"),
+            ("85025", "Complete CBC"),
+            ("80053", "Comprehensive metabolic panel"),
+            ("80061", "Lipid panel"),
+            ("81001", "Urinalysis automated"),
+            ("G0439", "Annual wellness visit, subsequent"),
+            ("G0438", "Annual wellness visit, initial"),
+            ("90471", "Immunization admin, 1st"),
+            ("96372", "Therapeutic injection, subq/im"),
+            ("99395", "Preventive visit, 18-39"),
+            ("99396", "Preventive visit, 40-64"),
+            ("93000", "Electrocardiogram, complete"),
+        ],
+        "allowed_range": (60, 250),
+    },
+    {
+        "type": "Physical Therapist in Private Practice",
+        "count": 80,
+        "codes": [
+            ("97110", "Therapeutic exercises"),
+            ("97140", "Manual therapy techniques"),
+            ("97530", "Therapeutic activities"),
+            ("97112", "Neuromuscular reeducation"),
+            ("97161", "PT evaluation, low complexity"),
+            ("97162", "PT evaluation, mod complexity"),
+            ("97163", "PT evaluation, high complexity"),
+            ("97116", "Gait training therapy"),
+            ("97035", "Ultrasound therapy"),
+            ("97010", "Hot/cold packs therapy"),
+            ("97542", "Wheelchair management"),
+            ("97150", "Group therapeutic procedures"),
+            ("97032", "Electrical stimulation"),
+            ("97033", "Iontophoresis"),
+            ("97164", "PT re-evaluation"),
+            ("97760", "Orthotic mgmt and training"),
+            ("97761", "Prosthetic training"),
+            ("97762", "C/O for orthotic/prosthetic"),
+            ("97750", "Physical performance test"),
+            ("97545", "Work hardening, initial 2 hr"),
+        ],
+        "allowed_range": (30, 120),
+    },
+    {
+        "type": "Cardiology",
+        "count": 50,
+        "codes": [
+            ("93000", "Electrocardiogram, complete"),
+            ("93010", "Electrocardiogram, report"),
+            ("93306", "TTE w/Doppler, complete"),
+            ("93005", "Electrocardiogram, tracing"),
+            ("93015", "Cardiovascular stress test"),
+            ("93017", "Stress test, tracing only"),
+            ("93018", "Stress test, interp/report"),
+            ("93320", "Doppler echo exam, complete"),
+            ("93225", "ECG monitoring, review"),
+            ("93224", "ECG monitoring, up to 48 hrs"),
+            ("93226", "ECG monitoring, scanning"),
+            ("93227", "ECG monitoring, review/report"),
+            ("93880", "Duplex scan, extracranial"),
+            ("93970", "Duplex scan, extremity veins"),
+            ("93971", "Duplex scan, unilateral"),
+        ],
+        "allowed_range": (80, 500),
+    },
+    {
+        "type": "Orthopedic Surgery",
+        "count": 50,
+        "codes": [
+            ("20610", "Arthrocentesis, major joint"),
+            ("20550", "Injection, tendon sheath"),
+            ("20600", "Arthrocentesis, small joint"),
+            ("20605", "Arthrocentesis, intermediate"),
+            ("27447", "Total knee arthroplasty"),
+            ("27130", "Total hip arthroplasty"),
+            ("29881", "Arthroscopy, knee, surgical"),
+            ("29880", "Arthroscopy, knee, meniscectomy"),
+            ("23472", "Arthroplasty, glenohumeral"),
+            ("28296", "Bunionectomy"),
+        ],
+        "allowed_range": (100, 800),
+    },
+]
+
+# Archetype distribution per specialty (proportional to specialty count)
+ARCHETYPE_RATIOS: dict[Archetype, float] = {
+    Archetype.STABLE: 0.35,
+    Archetype.REVIEW_MILD: 0.25,
+    Archetype.REVIEW_MID: 0.14,
+    Archetype.HIGH_RISK_Z: 0.15,
+    Archetype.HIGH_RISK_REVOKED: 0.05,
+    Archetype.NOT_ENROLLED: 0.06,
+}
+
+STATES = ["FL", "TX"]
+STATE_SPLIT = 0.80  # 80% FL, 20% TX
+
+CITIES: dict[str, list[tuple[str, str]]] = {
+    "FL": [
+        ("Miami", "33101"),
+        ("Orlando", "32801"),
+        ("Tampa", "33601"),
+        ("Jacksonville", "32099"),
+        ("Fort Lauderdale", "33301"),
+    ],
+    "TX": [
+        ("Houston", "77001"),
+        ("Dallas", "75201"),
+        ("Austin", "78701"),
+        ("San Antonio", "78201"),
+    ],
+}
+
+CREDENTIALS = ["M.D.", "D.O.", "P.T.", "D.P.T.", "PA-C", "NP"]
+FIRST_NAMES = [
+    "James",
+    "Maria",
+    "David",
+    "Sarah",
+    "Michael",
+    "Jennifer",
+    "Robert",
+    "Linda",
+    "William",
+    "Patricia",
+    "Richard",
+    "Elizabeth",
+    "Joseph",
+    "Susan",
+    "Thomas",
+    "Karen",
+    "Christopher",
+    "Nancy",
+    "Daniel",
+    "Lisa",
+]
+LAST_NAMES = [
+    "Smith",
+    "Johnson",
+    "Williams",
+    "Brown",
+    "Jones",
+    "Garcia",
+    "Miller",
+    "Davis",
+    "Rodriguez",
+    "Martinez",
+    "Hernandez",
+    "Lopez",
+    "Gonzalez",
+    "Wilson",
+    "Anderson",
+    "Thomas",
+    "Taylor",
+    "Moore",
+    "Jackson",
+    "Martin",
+]
+
+REVOCATION_REASONS = [
+    "False/Fraudulent Claims (42 CFR 424.535(a)(8)(i))",
+    "Felony Conviction (42 CFR 424.535(a)(3))",
+    "License Revocation/Suspension (42 CFR 424.535(a)(1))",
+]
+
+
+# ---------------------------------------------------------------------------
+# Provider record
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Provider:
+    npi: str
+    first_name: str
+    last_name: str
+    credentials: str
+    entity_code: str
+    city: str
+    state: str
+    zip5: str
+    provider_type: str
+    participating: str  # Y or N
+    archetype: Archetype
+    enrolled: bool
+    revoked: bool
+
+
+# ---------------------------------------------------------------------------
+# Z-score solver
+# ---------------------------------------------------------------------------
+
+
+def solve_outlier_value(baseline_values: list[float], z_target: float) -> float:
+    """Find value X such that z(X) within (baseline + [X]) approximates z_target.
+
+    Since adding X changes the mean and std, we iteratively adjust X until
+    the resulting z-score is within tolerance.
+    """
+    if len(baseline_values) < 2:
+        return max(baseline_values[0] * (1 + z_target * 0.5), 12.0) if baseline_values else 100.0
+    mean = statistics.mean(baseline_values)
+    std = statistics.pstdev(baseline_values)
+    if std == 0:
+        std = mean * 0.1  # fallback
+    # Initial guess: overshoot to account for mean/std shift
+    x = mean + z_target * std * 2.5
+    for _ in range(1000):
+        full = baseline_values + [x]
+        m = statistics.mean(full)
+        s = statistics.pstdev(full)
+        if s < 1e-9:
+            break
+        z_actual = (x - m) / s
+        error = z_target - z_actual
+        if abs(error) < 0.05:
+            break
+        x += error * s * 0.3
+    return max(x, 12.0)
+
+
+def gauss_clipped(rng: random.Random, mu: float, sigma: float, lo: float, hi: float) -> float:
+    return max(lo, min(hi, rng.gauss(mu, sigma)))
+
+
+# ---------------------------------------------------------------------------
+# Generation
+# ---------------------------------------------------------------------------
+
+
+def generate_providers(rng: random.Random) -> list[Provider]:
+    providers: list[Provider] = []
+    npi_counter = 1000000001
+
+    for spec in SPECIALTIES:
+        count = spec["count"]
+        ptype = spec["type"]
+
+        # Distribute archetypes
+        archetype_counts: dict[Archetype, int] = {}
+        remaining = count
+        for arch, ratio in ARCHETYPE_RATIOS.items():
+            n = max(1, round(count * ratio))
+            archetype_counts[arch] = n
+            remaining -= n
+        # Adjust STABLE to absorb rounding
+        archetype_counts[Archetype.STABLE] += remaining
+
+        for arch, n in archetype_counts.items():
+            for _ in range(n):
+                state = "FL" if rng.random() < STATE_SPLIT else "TX"
+                city, zip5 = rng.choice(CITIES[state])
+                enrolled = arch not in (Archetype.HIGH_RISK_REVOKED, Archetype.NOT_ENROLLED)
+                revoked = arch == Archetype.HIGH_RISK_REVOKED
+                participating = "Y" if arch != Archetype.HIGH_RISK_REVOKED else "N"
+
+                providers.append(
+                    Provider(
+                        npi=str(npi_counter),
+                        first_name=rng.choice(FIRST_NAMES),
+                        last_name=rng.choice(LAST_NAMES),
+                        credentials=rng.choice(CREDENTIALS),
+                        entity_code="I",  # Individual
+                        city=city,
+                        state=state,
+                        zip5=zip5,
+                        provider_type=ptype,
+                        participating=participating,
+                        archetype=arch,
+                        enrolled=enrolled,
+                        revoked=revoked,
+                    )
+                )
+                npi_counter += 1
+
+    rng.shuffle(providers)
+    return providers
+
+
+def generate_service_rows(rng: random.Random, providers: list[Provider]) -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+
+    # Group providers by specialty
+    by_type: dict[str, list[Provider]] = defaultdict(list)
+    for p in providers:
+        by_type[p.provider_type].append(p)
+
+    for spec in SPECIALTIES:
+        ptype = spec["type"]
+        codes = spec["codes"]
+        allowed_lo, allowed_hi = spec["allowed_range"]
+        type_providers = by_type[ptype]
+
+        for hcpcs_cd, hcpcs_desc in codes:
+            # Phase 1: generate baseline values for non-outlier providers
+            baseline_srvcs: list[float] = []
+            baseline_spb: list[float] = []
+            baseline_charge_ratio: list[float] = []
+            baseline_payment: list[float] = []
+
+            provider_values: dict[str, dict] = {}
+
+            for p in type_providers:
+                z_targets = Z_TARGETS[p.archetype]
+                is_baseline = all(t is None for t in z_targets)
+
+                allowed = gauss_clipped(
+                    rng,
+                    (allowed_lo + allowed_hi) / 2,
+                    (allowed_hi - allowed_lo) / 4,
+                    allowed_lo,
+                    allowed_hi,
+                )
+                benes = gauss_clipped(rng, 80, 40, 12, 400)
+                if p.archetype == Archetype.STABLE:
+                    benes = max(benes, 150)  # ensure large_patient_panel
+
+                if is_baseline:
+                    srvcs = gauss_clipped(rng, benes * 2.5, benes * 0.5, 12, benes * 6)
+                    spb = srvcs / benes
+                    charge_ratio = gauss_clipped(rng, 1.8, 0.3, 1.1, 3.5)
+                    payment = gauss_clipped(
+                        rng, allowed * 0.82, allowed * 0.05, allowed * 0.6, allowed * 0.95
+                    )
+
+                    baseline_srvcs.append(srvcs)
+                    baseline_spb.append(spb)
+                    baseline_charge_ratio.append(charge_ratio)
+                    baseline_payment.append(payment)
+
+                provider_values[p.npi] = {
+                    "allowed": allowed,
+                    "benes": benes,
+                }
+
+            # Phase 2: solve outlier values
+            for p in type_providers:
+                z_targets = Z_TARGETS[p.archetype]
+                vals = provider_values[p.npi]
+                allowed = vals["allowed"]
+                benes = vals["benes"]
+
+                z_vol, z_int, z_chr, z_pmt = z_targets
+
+                if z_vol is not None and baseline_srvcs:
+                    srvcs = solve_outlier_value(baseline_srvcs, z_vol)
+                else:
+                    mu = statistics.mean(baseline_srvcs) if baseline_srvcs else benes * 2.5
+                    sig = (
+                        statistics.pstdev(baseline_srvcs) * 0.5
+                        if len(baseline_srvcs) > 1
+                        else benes * 0.3
+                    )
+                    srvcs = gauss_clipped(rng, mu, sig, 12, 50000)
+
+                if z_int is not None and baseline_spb:
+                    target_spb = solve_outlier_value(baseline_spb, z_int)
+                    # Adjust srvcs to produce this spb, or adjust benes
+                    srvcs = max(srvcs, target_spb * benes)
+                    srvcs = max(srvcs, 12)
+
+                spb = srvcs / benes if benes > 0 else 1.0
+
+                if z_chr is not None and baseline_charge_ratio:
+                    charge_ratio = solve_outlier_value(baseline_charge_ratio, z_chr)
+                else:
+                    charge_ratio = gauss_clipped(rng, 1.8, 0.3, 1.1, 3.5)
+
+                if z_pmt is not None and baseline_payment:
+                    payment = solve_outlier_value(baseline_payment, z_pmt)
+                else:
+                    payment = gauss_clipped(
+                        rng, allowed * 0.82, allowed * 0.05, allowed * 0.6, allowed * 0.95
+                    )
+
+                submitted = allowed * charge_ratio
+                bene_day_srvcs = srvcs  # simplification
+
+                rows.append(
+                    {
+                        "Rndrng_NPI": p.npi,
+                        "Rndrng_Prvdr_Last_Org_Name": p.last_name,
+                        "Rndrng_Prvdr_First_Name": p.first_name,
+                        "Rndrng_Prvdr_Crdntls": p.credentials,
+                        "Rndrng_Prvdr_Ent_Cd": p.entity_code,
+                        "Rndrng_Prvdr_City": p.city,
+                        "Rndrng_Prvdr_State_Abrvtn": p.state,
+                        "Rndrng_Prvdr_Zip5": p.zip5,
+                        "Rndrng_Prvdr_Type": p.provider_type,
+                        "Rndrng_Prvdr_Mdcr_Prtcptg_Ind": p.participating,
+                        "HCPCS_Cd": hcpcs_cd,
+                        "HCPCS_Desc": hcpcs_desc,
+                        "Place_Of_Srvc": "O",
+                        "Tot_Benes": f"{max(12, round(benes))}",
+                        "Tot_Srvcs": f"{max(12, round(srvcs))}",
+                        "Tot_Bene_Day_Srvcs": f"{max(12, round(bene_day_srvcs))}",
+                        "Avg_Sbmtd_Chrg": f"{max(1.0, round(submitted, 2))}",
+                        "Avg_Mdcr_Alowd_Amt": f"{max(1.0, round(allowed, 2))}",
+                        "Avg_Mdcr_Pymt_Amt": f"{max(0.01, round(payment, 2))}",
+                    }
+                )
+
+    return rows
+
+
+def derive_provider_rows(
+    service_rows: list[dict[str, str]], providers: list[Provider]
+) -> list[dict[str, str]]:
+    # Aggregate service rows by NPI
+    agg: dict[str, dict] = defaultdict(
+        lambda: {
+            "codes": set(),
+            "max_benes": 0,
+            "total_srvcs": 0,
+            "total_payment": 0.0,
+        }
+    )
+    for row in service_rows:
+        npi = row["Rndrng_NPI"]
+        a = agg[npi]
+        a["codes"].add(row["HCPCS_Cd"])
+        benes = int(row["Tot_Benes"])
+        srvcs = int(row["Tot_Srvcs"])
+        pmt = float(row["Avg_Mdcr_Pymt_Amt"])
+        a["max_benes"] = max(a["max_benes"], benes)
+        a["total_srvcs"] += srvcs
+        a["total_payment"] += srvcs * pmt
+
+    prov_map = {p.npi: p for p in providers}
+    result = []
+    for npi, a in sorted(agg.items()):
+        p = prov_map[npi]
+        result.append(
+            {
+                "Rndrng_NPI": npi,
+                "Rndrng_Prvdr_Last_Org_Name": p.last_name,
+                "Rndrng_Prvdr_First_Name": p.first_name,
+                "Rndrng_Prvdr_City": p.city,
+                "Rndrng_Prvdr_State_Abrvtn": p.state,
+                "Rndrng_Prvdr_Zip5": p.zip5,
+                "Rndrng_Prvdr_Type": p.provider_type,
+                "Rndrng_Prvdr_Mdcr_Prtcptg_Ind": p.participating,
+                "Tot_HCPCS_Cds": str(len(a["codes"])),
+                "Tot_Benes": str(a["max_benes"]),
+                "Tot_Srvcs": str(a["total_srvcs"]),
+                "Tot_Mdcr_Pymt_Amt": f"{round(a['total_payment'], 2)}",
+            }
+        )
+    return result
+
+
+def generate_enrollment_rows(providers: list[Provider]) -> list[dict[str, str]]:
+    rows = []
+    for i, p in enumerate(providers):
+        if not p.enrolled:
+            continue
+        rows.append(
+            {
+                "NPI": p.npi,
+                "ENRLMT_ID": f"I20240101{i:06d}",
+                "PROVIDER_TYPE_CODE": "14" if "Medicine" in p.provider_type else "65",
+                "PROVIDER_TYPE_DESC": p.provider_type,
+                "STATE_CD": p.state,
+            }
+        )
+    return rows
+
+
+def generate_revocation_rows(rng: random.Random, providers: list[Provider]) -> list[dict[str, str]]:
+    rows = []
+    for p in providers:
+        if not p.revoked:
+            continue
+        rows.append(
+            {
+                "NPI": p.npi,
+                "REVOCATION_RSN": rng.choice(REVOCATION_REASONS),
+            }
+        )
+    return rows
+
+
+@dataclass
+class SyntheticDataset:
+    """All 4 generated CSV row sets plus metadata."""
+
+    service_rows: list[dict[str, str]]
+    provider_rows: list[dict[str, str]]
+    enrollment_rows: list[dict[str, str]]
+    revocation_rows: list[dict[str, str]]
+    providers: list[Provider]
+
+
+# Version strings used when loading into Postgres
+SYNTHETIC_VERSIONS: dict[str, str] = {
+    "part_b_service": "synthetic_2023",
+    "part_b_provider": "synthetic_2023",
+    "enrollment": "synthetic_q4_2025",
+    "revocations": "synthetic_q1_2026",
+}
+
+
+def generate_all(seed: int = SEED) -> SyntheticDataset:
+    """Generate all 4 synthetic CMS datasets in memory.
+
+    Returns a :class:`SyntheticDataset` with row lists ready for CSV writing
+    or direct loading via :func:`src.pipeline.raw_loader.load_raw_csv`.
+    """
+    rng = random.Random(seed)
+    providers = generate_providers(rng)
+    service_rows = generate_service_rows(rng, providers)
+    provider_rows = derive_provider_rows(service_rows, providers)
+    enrollment_rows = generate_enrollment_rows(providers)
+    revocation_rows = generate_revocation_rows(rng, providers)
+    return SyntheticDataset(
+        service_rows=service_rows,
+        provider_rows=provider_rows,
+        enrollment_rows=enrollment_rows,
+        revocation_rows=revocation_rows,
+        providers=providers,
+    )

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -734,6 +734,62 @@ class TestIngestStatus:
 
 
 # ---------------------------------------------------------------------------
+# Tests — POST /ingest/seed (synthetic data seeding)
+# ---------------------------------------------------------------------------
+
+
+class TestSeedSynthetic:
+    """Test the seed synthetic data endpoint."""
+
+    @pytest.mark.anyio
+    async def test_seed_returns_202_for_admin(self):
+        """Admin can trigger synthetic seed and gets 202 with run_id."""
+        # Fake conn: no running pipelines (count=0), then INSERT RETURNING id=99
+        no_running = _FakeCursor([(0,)])
+        insert_cur = _FakeCursor([(99,)])
+        conn = _MultiConn([no_running, insert_cur])
+        app = _make_app(fake_conn=conn)
+
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post("/api/ingest/seed", headers=_admin_headers())
+
+        assert resp.status_code == 202
+        body = resp.json()
+        assert body["id"] == 99
+        assert body["run_type"] == "seed_synthetic"
+        assert body["status"] == "running"
+
+    @pytest.mark.anyio
+    async def test_seed_returns_403_for_analyst(self):
+        """Non-admin users cannot trigger seed."""
+        app = _make_app()
+        headers = _analyst_headers()
+
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post("/api/ingest/seed", headers=headers)
+
+        assert resp.status_code == 403
+
+    @pytest.mark.anyio
+    async def test_seed_returns_409_when_pipeline_running(self):
+        """Seed rejects when a pipeline is already running."""
+        running_cur = _FakeCursor([(1,)])  # 1 running pipeline
+        conn = _MultiConn([running_cur])
+        app = _make_app(fake_conn=conn)
+
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post("/api/ingest/seed", headers=_admin_headers())
+
+        assert resp.status_code == 409
+
+
+# ---------------------------------------------------------------------------
 # Tests — require_admin dependency directly
 # ---------------------------------------------------------------------------
 

--- a/tests/test_synthetic.py
+++ b/tests/test_synthetic.py
@@ -1,0 +1,269 @@
+"""Tests for src/pipeline/synthetic.py — synthetic data generation.
+
+Covers the generation functions, z-score solver, dataset shape, and
+column correctness against the column_maps definitions.
+"""
+
+from __future__ import annotations
+
+import random
+
+import pytest
+
+from src.pipeline.column_maps import REQUIRED_COLUMNS
+from src.pipeline.synthetic import (
+    SEED,
+    SPECIALTIES,
+    SYNTHETIC_VERSIONS,
+    Archetype,
+    Provider,
+    SyntheticDataset,
+    derive_provider_rows,
+    generate_all,
+    generate_enrollment_rows,
+    generate_providers,
+    generate_revocation_rows,
+    generate_service_rows,
+    solve_outlier_value,
+)
+
+
+# ---------------------------------------------------------------------------
+# solve_outlier_value
+# ---------------------------------------------------------------------------
+
+
+class TestSolveOutlierValue:
+    def test_returns_value_above_baseline_mean(self):
+        baseline = [100.0, 110.0, 105.0, 95.0, 90.0] * 10
+        x = solve_outlier_value(baseline, 3.0)
+        assert x > max(baseline)
+
+    def test_z_target_2_produces_moderate_outlier(self):
+        baseline = [50.0 + i * 0.5 for i in range(50)]
+        x = solve_outlier_value(baseline, 2.0)
+        import statistics
+
+        full = baseline + [x]
+        m = statistics.mean(full)
+        s = statistics.pstdev(full)
+        z = (x - m) / s if s > 0 else 0
+        assert abs(z - 2.0) < 0.2
+
+    def test_z_target_5_produces_extreme_outlier(self):
+        baseline = [200.0 + random.gauss(0, 20) for _ in range(50)]
+        x = solve_outlier_value(baseline, 5.0)
+        import statistics
+
+        full = baseline + [x]
+        m = statistics.mean(full)
+        s = statistics.pstdev(full)
+        z = (x - m) / s if s > 0 else 0
+        assert abs(z - 5.0) < 0.5
+
+    def test_minimum_floor_12(self):
+        """Solver always returns >= 12.0 even for low z-targets."""
+        baseline = [100.0, 110.0, 90.0, 105.0, 95.0] * 5
+        x = solve_outlier_value(baseline, 0.5)
+        assert x >= 12.0
+
+    def test_single_element_baseline(self):
+        x = solve_outlier_value([100.0], 3.0)
+        assert x >= 12.0
+
+    def test_empty_baseline(self):
+        x = solve_outlier_value([], 3.0)
+        assert x >= 12.0
+
+
+# ---------------------------------------------------------------------------
+# generate_providers
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateProviders:
+    def test_count_matches_specialty_totals(self):
+        rng = random.Random(SEED)
+        providers = generate_providers(rng)
+        expected = sum(s["count"] for s in SPECIALTIES)
+        assert len(providers) == expected
+
+    def test_all_archetypes_present(self):
+        rng = random.Random(SEED)
+        providers = generate_providers(rng)
+        archetypes = {p.archetype for p in providers}
+        assert archetypes == set(Archetype)
+
+    def test_npis_are_unique(self):
+        rng = random.Random(SEED)
+        providers = generate_providers(rng)
+        npis = [p.npi for p in providers]
+        assert len(npis) == len(set(npis))
+
+    def test_stable_providers_are_enrolled_and_not_revoked(self):
+        rng = random.Random(SEED)
+        providers = generate_providers(rng)
+        for p in providers:
+            if p.archetype == Archetype.STABLE:
+                assert p.enrolled is True
+                assert p.revoked is False
+
+    def test_revoked_providers_are_not_enrolled(self):
+        rng = random.Random(SEED)
+        providers = generate_providers(rng)
+        for p in providers:
+            if p.archetype == Archetype.HIGH_RISK_REVOKED:
+                assert p.enrolled is False
+                assert p.revoked is True
+
+    def test_states_are_valid(self):
+        rng = random.Random(SEED)
+        providers = generate_providers(rng)
+        for p in providers:
+            assert p.state in ("FL", "TX")
+
+
+# ---------------------------------------------------------------------------
+# generate_service_rows
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateServiceRows:
+    """Uses a cached generate_all() result shared via module-level fixture."""
+
+    @pytest.fixture(scope="module")
+    def dataset(self):
+        return generate_all()
+
+    def test_all_rows_have_required_columns(self, dataset):
+        required = set(REQUIRED_COLUMNS["part_b_service"])
+        for row in dataset.service_rows[:10]:
+            assert required.issubset(set(row.keys()))
+
+    def test_all_rows_survive_etl_filter(self, dataset):
+        for row in dataset.service_rows:
+            assert int(row["Tot_Benes"]) >= 11
+            assert int(row["Tot_Srvcs"]) >= 11
+            assert float(row["Avg_Mdcr_Alowd_Amt"]) > 0
+
+    def test_row_count_is_positive(self, dataset):
+        assert len(dataset.service_rows) > 1000
+
+    def test_all_npis_in_provider_list(self, dataset):
+        provider_npis = {p.npi for p in dataset.providers}
+        row_npis = {r["Rndrng_NPI"] for r in dataset.service_rows}
+        assert row_npis.issubset(provider_npis)
+
+    def test_place_of_service_is_office(self, dataset):
+        for row in dataset.service_rows[:20]:
+            assert row["Place_Of_Srvc"] == "O"
+
+
+# ---------------------------------------------------------------------------
+# derive_provider_rows
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveProviderRows:
+    @pytest.fixture(scope="module")
+    def dataset(self):
+        return generate_all()
+
+    def test_one_row_per_npi(self, dataset):
+        npis = [r["Rndrng_NPI"] for r in dataset.provider_rows]
+        assert len(npis) == len(set(npis))
+
+    def test_has_required_columns(self, dataset):
+        required = set(REQUIRED_COLUMNS["part_b_provider"])
+        for row in dataset.provider_rows[:5]:
+            assert required.issubset(set(row.keys()))
+
+
+# ---------------------------------------------------------------------------
+# generate_enrollment_rows / generate_revocation_rows
+# ---------------------------------------------------------------------------
+
+
+class TestEnrollmentRevocation:
+    def test_enrollment_only_enrolled_providers(self):
+        rng = random.Random(SEED)
+        providers = generate_providers(rng)
+        rows = generate_enrollment_rows(providers)
+        enrolled_npis = {p.npi for p in providers if p.enrolled}
+        for row in rows:
+            assert row["NPI"] in enrolled_npis
+
+    def test_enrollment_has_required_columns(self):
+        rng = random.Random(SEED)
+        providers = generate_providers(rng)
+        rows = generate_enrollment_rows(providers)
+        required = set(REQUIRED_COLUMNS["enrollment"])
+        for row in rows[:5]:
+            assert required.issubset(set(row.keys()))
+
+    def test_revocations_only_revoked_providers(self):
+        rng = random.Random(SEED)
+        providers = generate_providers(rng)
+        rows = generate_revocation_rows(rng, providers)
+        revoked_npis = {p.npi for p in providers if p.revoked}
+        for row in rows:
+            assert row["NPI"] in revoked_npis
+
+    def test_revocations_has_required_columns(self):
+        rng = random.Random(SEED)
+        providers = generate_providers(rng)
+        rows = generate_revocation_rows(rng, providers)
+        required = set(REQUIRED_COLUMNS["revocations"])
+        for row in rows:
+            assert required.issubset(set(row.keys()))
+
+
+# ---------------------------------------------------------------------------
+# generate_all
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateAll:
+    @pytest.fixture(scope="module")
+    def dataset(self):
+        return generate_all()
+
+    def test_returns_synthetic_dataset(self, dataset):
+        assert isinstance(dataset, SyntheticDataset)
+
+    def test_dataset_has_all_four_row_sets(self, dataset):
+        assert len(dataset.service_rows) > 0
+        assert len(dataset.provider_rows) > 0
+        assert len(dataset.enrollment_rows) > 0
+        assert len(dataset.revocation_rows) > 0
+
+    def test_version_strings_defined(self):
+        assert "part_b_service" in SYNTHETIC_VERSIONS
+        assert "part_b_provider" in SYNTHETIC_VERSIONS
+        assert "enrollment" in SYNTHETIC_VERSIONS
+        assert "revocations" in SYNTHETIC_VERSIONS
+
+    def test_provider_count_matches(self, dataset):
+        assert len(dataset.providers) == len(dataset.provider_rows)
+
+
+# ---------------------------------------------------------------------------
+# Peer group coverage
+# ---------------------------------------------------------------------------
+
+
+class TestPeerGroupCoverage:
+    @pytest.fixture(scope="module")
+    def dataset(self):
+        return generate_all()
+
+    def test_every_peer_group_has_at_least_25_members(self, dataset):
+        """Each (provider_type, hcpcs_cd, place_of_service) group must have >= 25 rows."""
+        from collections import Counter
+
+        groups = Counter(
+            (r["Rndrng_Prvdr_Type"], r["HCPCS_Cd"], r["Place_Of_Srvc"])
+            for r in dataset.service_rows
+        )
+        for key, count in groups.items():
+            assert count >= 25, f"Peer group {key} has only {count} members"


### PR DESCRIPTION
## Summary

- One-click "Seed Synthetic Data" button on Data Management page
- Generates 250 providers (4,250 service lines) server-side, loads into Postgres, runs full 6-stage recalibration
- After completion, Live Monitor streams scored claims against synthetic data
- Fixes broken `triggerRecalibrate()` and `triggerRetrain()` API URLs

## Changes

| File | What |
|---|---|
| `src/pipeline/synthetic.py` | Reusable generation library with z-score solver |
| `scripts/generate_synthetic_data.py` | CLI wrapper for local CSV generation |
| `src/api/routes/ingest.py` | `POST /ingest/seed` endpoint (admin, 202, background task) |
| `frontend/src/lib/api.ts` | `seedSyntheticData()` + URL bug fixes |
| `frontend/src/pages/DataManagement.tsx` | "Demo Mode" seed button section |
| `tests/test_synthetic.py` | 28 tests (solver, providers, columns, peer groups) |
| `tests/test_ingest.py` | 3 seed endpoint tests (admin/analyst/concurrent) |
| `DataManagement.test.tsx` | 3 seed button tests |

## Test plan

- [x] `uv run pytest tests/test_synthetic.py` — 28 passed
- [x] `uv run pytest tests/test_ingest.py -k seed` — 3 passed
- [x] `cd frontend && npx vitest run src/pages/__tests__/DataManagement.test.tsx` — 38 passed
- [x] `uv run ruff check` + `mypy` — clean
- [x] `npx tsc --noEmit` + `eslint` — clean
- [ ] Deploy → Data Management → click "Seed Synthetic Data" → progress completes → Live Monitor streams