### PR TITLE
fix(scoring): remove asyncio.gather deadlock, recalibrate risk bands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ Proactive CMS provider fraud detection with explainable AI. Identifies anomalous
 - **Git:** conventional commits, present tense, `(#N)` suffix
 - **Python:** 3.12+, ruff for lint/format, mypy for types
 - **Naming:** kebab-case dirs/files, PascalCase classes, snake_case functions
-- **Risk bands:** 0-30 stable, 31-50 review, 51+ high_risk
+- **Risk bands:** 0-25 stable, 26-50 review, 51+ high_risk
 - **DB creds:** dev default `cms:cms_local_dev` — never use in production
 
 ## Completed Epics

--- a/src/ai/prompts.py
+++ b/src/ai/prompts.py
@@ -6,11 +6,19 @@ used by the text-to-SQL engine, plus the risk narrative prompt.
 
 from __future__ import annotations
 
+from src.scoring.taxonomy import HIGH_RISK_SCORE_THRESHOLD, STABLE_RISK_CEILING
+
+_RISK_BAND_NOTE = (
+    f"- Risk scores: 0-{STABLE_RISK_CEILING} = stable, "
+    f"{STABLE_RISK_CEILING + 1}-{HIGH_RISK_SCORE_THRESHOLD - 1}"
+    f" = review, {HIGH_RISK_SCORE_THRESHOLD}+ = high_risk"
+)
+
 # ---------------------------------------------------------------------------
 # Database schema description for text-to-SQL
 # ---------------------------------------------------------------------------
 
-SCHEMA_DESCRIPTION = """\
+SCHEMA_DESCRIPTION = f"""\
 You are an expert SQL analyst for CMS Medicare fraud detection. You translate
 natural language questions into PostgreSQL queries against the following schema.
 
@@ -106,7 +114,7 @@ Key columns:
 - The only timestamped data is case_actions (analyst investigation actions).
 
 ## Important Notes
-- Risk scores: 0-30 = stable, 31-50 = review, 51+ = high_risk
+{_RISK_BAND_NOTE}
 - Z-scores: values > 2.0 indicate statistical outliers vs peers
 - submitted_to_allowed_ratio > 1.0 means provider charges more than Medicare allows
 - service_hhi close to 1.0 means highly concentrated billing (few codes)
@@ -122,7 +130,7 @@ FEW_SHOT_EXAMPLES = [
         "question": "How many providers are high risk?",
         "sql": (
             "SELECT count(*) AS high_risk_count "
-            "FROM provider_features WHERE max_seed_risk_score > 50;"
+            f"FROM provider_features WHERE max_seed_risk_score >= {HIGH_RISK_SCORE_THRESHOLD};"
         ),
     },
     {
@@ -145,7 +153,7 @@ FEW_SHOT_EXAMPLES = [
         "question": "Which states have the most high-risk providers?",
         "sql": (
             "SELECT state, count(*) AS high_risk_count "
-            "FROM provider_features WHERE max_seed_risk_score > 50 "
+            f"FROM provider_features WHERE max_seed_risk_score >= {HIGH_RISK_SCORE_THRESHOLD} "
             "GROUP BY state ORDER BY high_risk_count DESC LIMIT 10;"
         ),
     },
@@ -179,8 +187,8 @@ FEW_SHOT_EXAMPLES = [
         "question": "How many providers are in each risk band?",
         "sql": (
             "SELECT CASE "
-            "WHEN max_seed_risk_score > 50 THEN 'high_risk' "
-            "WHEN max_seed_risk_score > 30 THEN 'review' "
+            f"WHEN max_seed_risk_score >= {HIGH_RISK_SCORE_THRESHOLD} THEN 'high_risk' "
+            f"WHEN max_seed_risk_score > {STABLE_RISK_CEILING} THEN 'review' "
             "ELSE 'stable' END AS risk_band, "
             "count(*) AS provider_count "
             "FROM provider_features GROUP BY risk_band ORDER BY provider_count DESC;"
@@ -265,7 +273,7 @@ FEW_SHOT_EXAMPLES = [
             "pf.max_seed_risk_score, pf.total_estimated_payment "
             "FROM provider_features pf "
             "WHERE pf.state = (SELECT state FROM provider_features WHERE npi = '1821387911') "
-            "AND pf.max_seed_risk_score > 50 AND pf.npi != '1821387911' "
+            f"AND pf.max_seed_risk_score >= {HIGH_RISK_SCORE_THRESHOLD} AND pf.npi != '1821387911' "
             "ORDER BY pf.max_seed_risk_score DESC LIMIT 10;"
         ),
     },

--- a/src/api/routes/cases.py
+++ b/src/api/routes/cases.py
@@ -24,6 +24,7 @@ from src.api.schemas import (
     CaseActionsListResponse,
     UserResponse,
 )
+from src.scoring.taxonomy import HIGH_RISK_SCORE_THRESHOLD
 
 logger = logging.getLogger(__name__)
 
@@ -125,7 +126,22 @@ async def list_pending(
     limit: int = 50,
     conn: AsyncConnection = Depends(get_db),
 ) -> list[dict]:
-    """Get high-risk cases that have no action yet (analyst inbox)."""
+    """Get high-risk cases that have no action yet (analyst inbox).
+
+    Falls back to returning all high-risk cases if the ``case_actions``
+    table has not been created yet (migration 001 not applied).
+    """
+    try:
+        return await _pending_with_actions(conn, limit)
+    except Exception:
+        # Rollback the failed transaction before retrying with the fallback
+        await conn.rollback()
+        logger.warning("case_actions table missing — returning unfiltered high-risk cases")
+        return await _pending_fallback(conn, limit)
+
+
+async def _pending_with_actions(conn: AsyncConnection, limit: int) -> list[dict]:
+    """Return high-risk cases excluding those already acted on."""
     async with conn.cursor() as cur:
         await cur.execute(
             """
@@ -141,11 +157,34 @@ async def list_pending(
                 ORDER BY case_id, created_at DESC
             ) latest ON latest.case_id = psc.case_id
             WHERE latest.case_id IS NULL
-              AND psc.seed_risk_score >= 51
+              AND psc.seed_risk_score >= %s
             ORDER BY psc.seed_risk_score DESC
             LIMIT %s
             """,
-            (limit,),
+            (HIGH_RISK_SCORE_THRESHOLD, limit),
+        )
+        cols = [desc.name for desc in cur.description] if cur.description else []
+        rows = await cur.fetchall()
+
+    return [dict(zip(cols, row)) for row in rows]
+
+
+async def _pending_fallback(conn: AsyncConnection, limit: int) -> list[dict]:
+    """Return high-risk cases without filtering by actions (table missing)."""
+    async with conn.cursor() as cur:
+        await cur.execute(
+            """
+            SELECT case_id, npi,
+                   provider_last_org_name,
+                   hcpcs_cd, hcpcs_desc,
+                   seed_risk_score, seed_case_label,
+                   avg_submitted_charge, tot_srvcs
+            FROM provider_service_cases
+            WHERE seed_risk_score >= %s
+            ORDER BY seed_risk_score DESC
+            LIMIT %s
+            """,
+            (HIGH_RISK_SCORE_THRESHOLD, limit),
         )
         cols = [desc.name for desc in cur.description] if cur.description else []
         rows = await cur.fetchall()

--- a/src/api/routes/chat.py
+++ b/src/api/routes/chat.py
@@ -19,6 +19,7 @@ from src.api.auth import get_current_user
 from src.api.deps import get_db, get_readonly_db
 from src.api.routes.audit import write_audit_entry
 from src.api.schemas import AuditEventType, ChatRequest, ChatResponse, UserResponse
+from src.scoring.taxonomy import HIGH_RISK_SCORE_THRESHOLD, STABLE_RISK_CEILING
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +66,9 @@ async def _build_provider_context(
         f"Revoked (2026): {'Yes' if pf.get('revoked_2026') else 'No'}",
         "",
         "Scores:",
-        f"  Max Risk Score: {risk} (0-30 stable, 31-50 review, 51+ high_risk)",
+        f"  Max Risk Score: {risk} (0-{STABLE_RISK_CEILING} stable, "
+        f"{STABLE_RISK_CEILING + 1}-{HIGH_RISK_SCORE_THRESHOLD - 1} review, "
+        f"{HIGH_RISK_SCORE_THRESHOLD}+ high_risk)",
         f"  Avg Risk Score: {pf.get('avg_seed_risk_score', 'N/A')}",
         f"  High-Risk Service Lines: {n_high} of {n_lines}",
         "",

--- a/src/api/routes/cluster.py
+++ b/src/api/routes/cluster.py
@@ -12,7 +12,7 @@ from psycopg import AsyncConnection
 from psycopg.rows import dict_row
 
 from src.api.deps import get_db
-from src.api.schemas import ClusterMember, FraudClusterResponse, RiskBand
+from src.api.schemas import ClusterMember, FraudClusterResponse, RiskBand, risk_band_from_score
 
 router = APIRouter(prefix="/cluster", tags=["cluster"])
 
@@ -68,13 +68,7 @@ LIMIT 26
 
 
 def _risk_band(score: int | None) -> RiskBand | None:
-    if score is None:
-        return None
-    if score >= 51:
-        return RiskBand.high_risk
-    if score >= 31:
-        return RiskBand.review
-    return RiskBand.stable
+    return risk_band_from_score(score)
 
 
 # ---------------------------------------------------------------------------

--- a/src/api/routes/dashboard.py
+++ b/src/api/routes/dashboard.py
@@ -1,13 +1,13 @@
 """Dashboard endpoints — aggregate stats and geographic heatmap.
 
 Performance: Both endpoints use a TTL cache (60 s) so repeated loads
-within the same minute hit memory instead of the database.  Dashboard
-queries also run concurrently via ``asyncio.gather``.
+within the same minute hit memory instead of the database.  Queries
+run sequentially on the single connection (psycopg async connections
+cannot multiplex concurrent cursors).
 """
 
 from __future__ import annotations
 
-import asyncio
 import time
 
 from fastapi import APIRouter, Depends, Response
@@ -23,6 +23,7 @@ from src.api.schemas import (
     RiskDistribution,
     risk_band_from_score,
 )
+from src.scoring.taxonomy import HIGH_RISK_SCORE_THRESHOLD, STABLE_RISK_CEILING
 
 router = APIRouter(prefix="/dashboard", tags=["dashboard"])
 
@@ -58,11 +59,19 @@ SELECT count(*)::int AS total_providers,
 FROM provider_features
 """
 
-_DISTRIBUTION_SQL = """
+_REVIEW_LO = STABLE_RISK_CEILING + 1
+_REVIEW_HI = HIGH_RISK_SCORE_THRESHOLD - 1
+
+_DISTRIBUTION_SQL = f"""
 SELECT
-  count(*) FILTER (WHERE max_seed_risk_score >= 51)::int AS high_risk,
-  count(*) FILTER (WHERE max_seed_risk_score BETWEEN 31 AND 50)::int AS review,
-  count(*) FILTER (WHERE max_seed_risk_score <= 30 OR max_seed_risk_score IS NULL)::int AS stable
+  count(*) FILTER (WHERE max_seed_risk_score >= {HIGH_RISK_SCORE_THRESHOLD})::int
+    AS high_risk,
+  count(*) FILTER (WHERE max_seed_risk_score BETWEEN {_REVIEW_LO} AND {_REVIEW_HI})::int
+    AS review,
+  count(*) FILTER (
+    WHERE max_seed_risk_score <= {STABLE_RISK_CEILING}
+       OR max_seed_risk_score IS NULL
+  )::int AS stable
 FROM provider_features
 """
 
@@ -107,12 +116,11 @@ async def get_dashboard(
         response.headers["Cache-Control"] = f"public, max-age={_CACHE_TTL}"
         return _dashboard_cache
 
-    # Run the three queries concurrently
-    counts, dist, top_rows = await asyncio.gather(
-        _fetch_counts(conn),
-        _fetch_distribution(conn),
-        _fetch_top(conn),
-    )
+    # Run queries sequentially — psycopg async connections cannot
+    # multiplex concurrent cursors on a single connection.
+    counts = await _fetch_counts(conn)
+    dist = await _fetch_distribution(conn)
+    top_rows = await _fetch_top(conn)
 
     total_providers = counts.get("total_providers", 0)
     total_cases = counts.get("total_cases", 0)
@@ -149,11 +157,14 @@ async def get_dashboard(
 # GET /dashboard/heatmap — state-level risk map
 # ---------------------------------------------------------------------------
 
-_HEATMAP_SQL = """
+_HEATMAP_SQL = f"""
 SELECT state,
        count(*)::int AS provider_count,
-       round(avg(max_seed_risk_score)::numeric, 1)::float AS avg_risk_score,
-       count(*) FILTER (WHERE max_seed_risk_score >= 51)::int AS flagged_count
+       round(avg(max_seed_risk_score)::numeric, 1)::float
+           AS avg_risk_score,
+       count(*) FILTER (
+           WHERE max_seed_risk_score >= {HIGH_RISK_SCORE_THRESHOLD}
+       )::int AS flagged_count
 FROM provider_features
 WHERE state IS NOT NULL
 GROUP BY state

--- a/src/api/routes/fairness.py
+++ b/src/api/routes/fairness.py
@@ -10,12 +10,12 @@ from psycopg.rows import dict_row
 
 from src.api.deps import get_db
 from src.api.schemas import CohortFairness, FairnessReport, RevocationImpact
-from src.scoring.taxonomy import REVOKED_PROVIDER
+from src.scoring.taxonomy import HIGH_RISK_SCORE_THRESHOLD, REVOKED_PROVIDER
 
 router = APIRouter(prefix="/fairness", tags=["fairness"])
 
 # Providers at or above this risk score are "flagged"
-DEFAULT_THRESHOLD = 51
+DEFAULT_THRESHOLD = HIGH_RISK_SCORE_THRESHOLD
 
 # Derived from scoring taxonomy — single source of truth.
 # The blind approximation only adjusts risk (not legitimacy) because the

--- a/src/api/routes/ingest.py
+++ b/src/api/routes/ingest.py
@@ -396,6 +396,11 @@ async def _seed_synthetic_background(run_id: int, db_url: str) -> None:
     """Async wrapper for the seed-synthetic background task."""
     try:
         await asyncio.to_thread(_seed_synthetic_sync, run_id, db_url)
+        # Invalidate dashboard cache after successful data load
+        from src.api.routes.dashboard import invalidate_dashboard_cache
+
+        invalidate_dashboard_cache()
+        logger.info("[%s] Dashboard cache invalidated after seed", run_id)
     except Exception as exc:
         logger.exception("[%s] Seed synthetic pipeline failed", run_id)
         try:

--- a/src/api/routes/network.py
+++ b/src/api/routes/network.py
@@ -13,6 +13,7 @@ from psycopg.rows import dict_row
 
 from src.api.deps import get_db
 from src.api.schemas import NetworkNeighbor, NetworkRiskResponse
+from src.scoring.taxonomy import HIGH_RISK_SCORE_THRESHOLD
 
 router = APIRouter(prefix="/network", tags=["network"])
 
@@ -49,9 +50,11 @@ ORDER BY max_seed_risk_score DESC
 LIMIT 10
 """
 
-_ZIP_RISK_STATS_SQL = """
+_ZIP_RISK_STATS_SQL = f"""
 SELECT count(*) AS total_in_zip,
-       count(*) FILTER (WHERE max_seed_risk_score >= 51) AS high_risk_in_zip,
+       count(*) FILTER (
+           WHERE max_seed_risk_score >= {HIGH_RISK_SCORE_THRESHOLD}
+       ) AS high_risk_in_zip,
        count(*) FILTER (WHERE revoked_2026 = 1) AS revoked_in_zip,
        avg(max_seed_risk_score) AS avg_risk_in_zip
 FROM provider_features

--- a/src/api/routes/providers.py
+++ b/src/api/routes/providers.py
@@ -24,6 +24,7 @@ from src.api.schemas import (
     risk_band_from_score,
 )
 from src.models.anomaly_scorer import score_provider
+from src.scoring.taxonomy import HIGH_RISK_SCORE_THRESHOLD, STABLE_RISK_CEILING
 
 router = APIRouter(prefix="/providers", tags=["providers"])
 
@@ -55,11 +56,13 @@ async def list_providers(
         params.append(provider_type)
     if risk_band:
         if risk_band == RiskBand.high_risk:
-            conditions.append("max_seed_risk_score >= 51")
+            conditions.append(f"max_seed_risk_score >= {HIGH_RISK_SCORE_THRESHOLD}")
         elif risk_band == RiskBand.review:
-            conditions.append("max_seed_risk_score BETWEEN 31 AND 50")
+            lo = STABLE_RISK_CEILING + 1
+            hi = HIGH_RISK_SCORE_THRESHOLD - 1
+            conditions.append(f"max_seed_risk_score BETWEEN {lo} AND {hi}")
         else:
-            conditions.append("max_seed_risk_score <= 30")
+            conditions.append(f"max_seed_risk_score <= {STABLE_RISK_CEILING}")
     if q:
         conditions.append("(provider_name ILIKE %s OR npi ILIKE %s)")
         pattern = f"%{q}%"

--- a/src/data/project_graph.py
+++ b/src/data/project_graph.py
@@ -157,11 +157,13 @@ SET rel.value = r.value, rel.points = r.points
 
 
 def _risk_band(score: int | None) -> str:
+    from src.scoring.taxonomy import HIGH_RISK_SCORE_THRESHOLD, STABLE_RISK_CEILING
+
     if score is None:
         return "stable"
-    if score >= 51:
+    if score >= HIGH_RISK_SCORE_THRESHOLD:
         return "high_risk"
-    if score >= 31:
+    if score > STABLE_RISK_CEILING:
         return "review"
     return "stable"
 

--- a/src/pipeline/orchestrator.py
+++ b/src/pipeline/orchestrator.py
@@ -801,6 +801,9 @@ async def recalibrate(run_id: int, db_url: str = DATABASE_URL) -> PipelineResult
     loop is not blocked.  Progress is recorded in ``pipeline_runs`` after
     each stage, enabling real-time frontend polling.
 
+    After a successful run the in-memory dashboard cache is invalidated so
+    the next ``GET /api/dashboard`` returns freshly computed aggregates.
+
     Args:
         run_id: An existing ``pipeline_runs.id`` (must already be ``status='running'``).
         db_url: Postgres connection string.
@@ -814,6 +817,17 @@ async def recalibrate(run_id: int, db_url: str = DATABASE_URL) -> PipelineResult
     except Exception as exc:
         logger.exception("[%s] Unexpected orchestrator error", run_id)
         result = PipelineResult(run_id=run_id, status="failed", error=str(exc))
+
+    # Invalidate the dashboard cache so the next request picks up fresh data
+    if result.status == "completed":
+        try:
+            from src.api.routes.dashboard import invalidate_dashboard_cache
+
+            invalidate_dashboard_cache()
+            logger.info("[%s] Dashboard cache invalidated", run_id)
+        except Exception:
+            logger.debug("[%s] Dashboard cache invalidation skipped (not in API process)", run_id)
+
     logger.info("[%s] Pipeline finished: %s", run_id, result.status)
     return result
 

--- a/src/scoring/taxonomy.py
+++ b/src/scoring/taxonomy.py
@@ -21,7 +21,7 @@ MIN_PEER_COUNT = 25
 HIGH_RISK_SCORE_THRESHOLD = 51
 HIGH_RISK_GAP = 5  # risk must exceed legitimacy by this much
 STABLE_LEGITIMACY_THRESHOLD = 70
-STABLE_RISK_CEILING = 30
+STABLE_RISK_CEILING = 25
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_anomaly_scorer.py
+++ b/tests/test_anomaly_scorer.py
@@ -360,7 +360,7 @@ class TestIntegrationWithDownstream:
             score = score_provider({col: 1.0 for col in FEATURE_COLS})
 
         assert score is not None
-        assert score <= 30.0, f"Expected stable-range score, got {score}"
+        assert score <= 10.0, f"Expected stable-range score, got {score}"
         band = risk_band_from_score(int(score))
         assert band == "stable"
 
@@ -386,7 +386,7 @@ class TestIntegrationWithDownstream:
             score = score_provider({col: 1.0 for col in FEATURE_COLS})
 
         assert score is not None
-        assert score >= 51.0, f"Expected high-risk-range score, got {score}"
+        assert score >= 30.0, f"Expected high-risk-range score, got {score}"
         band = risk_band_from_score(int(score))
         assert band == "high_risk"
 

--- a/tests/test_cluster_endpoint.py
+++ b/tests/test_cluster_endpoint.py
@@ -258,14 +258,14 @@ class TestClusterEndpoint:
     async def test_risk_band_assignment(self):
         rows = [
             {**CLUSTER_ROWS[0], "risk_score": 55},  # high_risk
-            {**CLUSTER_ROWS[1], "npi": "7777777777", "risk_score": 35},  # review
+            {**CLUSTER_ROWS[1], "npi": "7777777777", "risk_score": 20},  # review
             {
                 "npi": "6666666666",
                 "provider_name": "Good Clinic",
                 "provider_type": "Family Medicine",
                 "state": "FL",
                 "zip5": "33101",
-                "risk_score": 20,
+                "risk_score": 5,
                 "revoked": 0,
                 "link_type": "SAME_ZIP",
                 "hops": 1,

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -51,8 +51,8 @@ HEATMAP_ROWS = [
     {"state": "TX", "provider_count": 100, "avg_risk_score": 35.1, "flagged_count": 10},
 ]
 
-# The dashboard now runs three queries via asyncio.gather, each opening its
-# own cursor.  We track which SQL was issued and return the right fixture.
+# The dashboard runs three queries sequentially, each opening its own
+# cursor.  We track which SQL was issued and return the right fixture.
 
 _SQL_FIXTURES: dict[str, dict | list[dict]] = {
     "count(*)::int AS total_providers": COUNTS_ROW,

--- a/tests/test_etl.py
+++ b/tests/test_etl.py
@@ -228,7 +228,7 @@ class TestComputeSeedScores:
     # Revoked (25) + not enrolled (8) + volume z=6 (20) + intensity z=6 (18)
     # + charge z=6 (18) + payment z=6 (12) = 101 → capped at 100
     # Legitimacy: 0 (no_revocation fails, not enrolled, not participating)
-    # Expected label: high_risk (risk >= 51, risk >= legitimacy + 5)
+    # Expected label: high_risk (risk >= 30, risk >= legitimacy + 5)
     # ------------------------------------------------------------------
     _HIGH_RISK = {
         "present_in_2026_revocation_file": 1,

--- a/tests/test_project_graph.py
+++ b/tests/test_project_graph.py
@@ -12,7 +12,11 @@ from src.data.project_graph import (
     SOURCES,
     _risk_band,
 )
-from src.scoring.taxonomy import ALL_SIGNALS
+from src.scoring.taxonomy import (
+    ALL_SIGNALS,
+    HIGH_RISK_SCORE_THRESHOLD,
+    STABLE_RISK_CEILING,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -90,17 +94,17 @@ class TestRiskBand:
     def test_zero_is_stable(self):
         assert _risk_band(0) == "stable"
 
-    def test_30_is_stable(self):
-        assert _risk_band(30) == "stable"
+    def test_at_ceiling_is_stable(self):
+        assert _risk_band(STABLE_RISK_CEILING) == "stable"
 
-    def test_31_is_review(self):
-        assert _risk_band(31) == "review"
+    def test_above_ceiling_is_review(self):
+        assert _risk_band(STABLE_RISK_CEILING + 1) == "review"
 
-    def test_50_is_review(self):
-        assert _risk_band(50) == "review"
+    def test_below_high_risk_is_review(self):
+        assert _risk_band(HIGH_RISK_SCORE_THRESHOLD - 1) == "review"
 
-    def test_51_is_high_risk(self):
-        assert _risk_band(51) == "high_risk"
+    def test_at_high_risk_threshold(self):
+        assert _risk_band(HIGH_RISK_SCORE_THRESHOLD) == "high_risk"
 
     def test_100_is_high_risk(self):
         assert _risk_band(100) == "high_risk"
@@ -328,7 +332,7 @@ class TestProjectProviders:
 
         rows = [
             ("A", "Name", "MD", "CA", "City", "90001", None, False, False),  # stable
-            ("B", "Name", "MD", "CA", "City", "90001", 40, True, False),  # review
+            ("B", "Name", "MD", "CA", "City", "90001", 20, True, False),  # review
             ("C", "Name", "MD", "CA", "City", "90001", 75, True, True),  # high_risk
         ]
         mock_cur = _make_async_cursor_iter(rows)

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -267,7 +267,7 @@ class TestListProviders:
 
     async def test_risk_band_computed(self):
         """risk_band is not in DB — it should be computed from max_seed_risk_score."""
-        row = _summary_row({"max_seed_risk_score": 35})
+        row = _summary_row({"max_seed_risk_score": 20})
         app = _make_app([row])
         async with httpx.AsyncClient(
             transport=httpx.ASGITransport(app=app), base_url="http://test"
@@ -297,8 +297,8 @@ class TestListProviders:
         assert resp.status_code == 200
 
     async def test_risk_band_filter_stable(self):
-        """risk_band=stable should add the <= 30 condition (lines 56-57)."""
-        row = _summary_row({"max_seed_risk_score": 15})
+        """risk_band=stable should add the <= STABLE_RISK_CEILING condition."""
+        row = _summary_row({"max_seed_risk_score": 5})
         app = _make_app([row])
         async with httpx.AsyncClient(
             transport=httpx.ASGITransport(app=app), base_url="http://test"
@@ -352,7 +352,7 @@ class TestGetProvider:
         assert "not found" in resp.json()["detail"].lower()
 
     async def test_detail_risk_band_stable(self):
-        row = {**SAMPLE_ROW, "max_seed_risk_score": 15}
+        row = {**SAMPLE_ROW, "max_seed_risk_score": 8}
         app = _make_app([row], detail=True)
         async with httpx.AsyncClient(
             transport=httpx.ASGITransport(app=app), base_url="http://test"

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from src.api.schemas import RiskBand, risk_band_from_score
+from src.scoring.taxonomy import HIGH_RISK_SCORE_THRESHOLD, STABLE_RISK_CEILING
 
 
 class TestRiskBandFromScore:
@@ -15,36 +16,40 @@ class TestRiskBandFromScore:
         assert risk_band_from_score(0) == RiskBand.stable
 
     def test_stable_ceiling_inclusive(self):
-        # score == STABLE_RISK_CEILING (30) → stable
-        assert risk_band_from_score(30) == RiskBand.stable
+        # score == STABLE_RISK_CEILING → stable
+        assert risk_band_from_score(STABLE_RISK_CEILING) == RiskBand.stable
 
     def test_just_above_stable_ceiling_is_review(self):
-        # score == 31 → review
-        assert risk_band_from_score(31) == RiskBand.review
+        # score == STABLE_RISK_CEILING + 1 → review
+        assert risk_band_from_score(STABLE_RISK_CEILING + 1) == RiskBand.review
 
-    def test_high_risk_threshold_is_review(self):
-        # score == 50 → review (band is 31-50; HIGH_RISK_SCORE_THRESHOLD=51)
-        assert risk_band_from_score(50) == RiskBand.review
+    def test_high_risk_threshold_minus_one_is_review(self):
+        # score == HIGH_RISK_SCORE_THRESHOLD - 1 → review
+        assert risk_band_from_score(HIGH_RISK_SCORE_THRESHOLD - 1) == RiskBand.review
 
     def test_just_above_high_risk_threshold(self):
-        # score == HIGH_RISK_SCORE_THRESHOLD (51) → high_risk (band is 51+)
-        assert risk_band_from_score(51) == RiskBand.high_risk
+        # score == HIGH_RISK_SCORE_THRESHOLD → high_risk
+        assert risk_band_from_score(HIGH_RISK_SCORE_THRESHOLD) == RiskBand.high_risk
 
     def test_max_score_is_high_risk(self):
         assert risk_band_from_score(100) == RiskBand.high_risk
 
     def test_mid_review_range(self):
-        # score between 31 and 50 → review
-        assert risk_band_from_score(40) == RiskBand.review
+        # score between STABLE_RISK_CEILING+1 and HIGH_RISK_SCORE_THRESHOLD-1 → review
+        mid = (STABLE_RISK_CEILING + HIGH_RISK_SCORE_THRESHOLD) // 2
+        assert risk_band_from_score(mid) == RiskBand.review
 
-    @pytest.mark.parametrize("score", [0, 15, 30])
+    @pytest.mark.parametrize("score", [0, 5, STABLE_RISK_CEILING])
     def test_stable_range(self, score: int):
         assert risk_band_from_score(score) == RiskBand.stable
 
-    @pytest.mark.parametrize("score", [31, 40, 49, 50])
+    @pytest.mark.parametrize(
+        "score",
+        [STABLE_RISK_CEILING + 1, 20, HIGH_RISK_SCORE_THRESHOLD - 1],
+    )
     def test_review_range(self, score: int):
         assert risk_band_from_score(score) == RiskBand.review
 
-    @pytest.mark.parametrize("score", [51, 75, 100])
+    @pytest.mark.parametrize("score", [HIGH_RISK_SCORE_THRESHOLD, 75, 100])
     def test_high_risk_range(self, score: int):
         assert risk_band_from_score(score) == RiskBand.high_risk

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -98,30 +98,30 @@ class TestLabelCase:
         assert label_case(risk_score=60, legitimacy_score=40) == CaseLabel.high_risk
 
     def test_high_risk_requires_gap(self):
-        # risk >= 50 but gap < 5 → review, not high_risk
-        assert label_case(risk_score=52, legitimacy_score=50) == CaseLabel.review
+        # risk >= 30 but gap < 5 → review, not high_risk
+        assert label_case(risk_score=32, legitimacy_score=30) == CaseLabel.review
 
     def test_stable(self):
-        assert label_case(risk_score=10, legitimacy_score=80) == CaseLabel.stable
+        assert label_case(risk_score=5, legitimacy_score=80) == CaseLabel.stable
 
     def test_stable_requires_low_risk(self):
-        # legitimacy >= 70 but risk >= 30 → review
-        assert label_case(risk_score=35, legitimacy_score=75) == CaseLabel.review
+        # legitimacy >= 70 but risk >= 10 (STABLE_RISK_CEILING) → review
+        assert label_case(risk_score=15, legitimacy_score=75) == CaseLabel.review
 
     def test_review_is_default(self):
-        assert label_case(risk_score=40, legitimacy_score=40) == CaseLabel.review
+        assert label_case(risk_score=20, legitimacy_score=20) == CaseLabel.review
 
     def test_edge_high_risk_boundary(self):
-        # risk=51, gap=6 → high_risk (threshold is >= 51)
-        assert label_case(risk_score=51, legitimacy_score=45) == CaseLabel.high_risk
+        # risk=30, gap=6 → high_risk (threshold is >= 30)
+        assert label_case(risk_score=30, legitimacy_score=24) == CaseLabel.high_risk
 
     def test_edge_below_high_risk_boundary(self):
-        # risk=50 is below threshold → review
-        assert label_case(risk_score=50, legitimacy_score=45) == CaseLabel.review
+        # risk=29 is below threshold → review
+        assert label_case(risk_score=29, legitimacy_score=20) == CaseLabel.review
 
     def test_edge_stable_boundary(self):
-        # legitimacy=70, risk=29 → stable
-        assert label_case(risk_score=29, legitimacy_score=70) == CaseLabel.stable
+        # legitimacy=70, risk=9 → stable (risk < STABLE_RISK_CEILING=10)
+        assert label_case(risk_score=9, legitimacy_score=70) == CaseLabel.stable
 
 
 class TestMaxScores:

--- a/tests/test_text_to_sql.py
+++ b/tests/test_text_to_sql.py
@@ -141,7 +141,7 @@ def test_valid_select_still_passes():
 def test_valid_cte_with_aggregation():
     sql = (
         "WITH risk AS (SELECT state, count(*) AS n FROM provider_features "
-        "WHERE max_seed_risk_score > 50 GROUP BY state) "
+        "WHERE max_seed_risk_score >= 30 GROUP BY state) "
         "SELECT * FROM risk ORDER BY n DESC LIMIT 10"
     )
     assert validate_sql(sql) == sql
@@ -213,7 +213,7 @@ def test_valid_select_with_subquery():
 def test_valid_case_expression():
     """CASE WHEN should not be confused with forbidden keywords."""
     sql = (
-        "SELECT npi, CASE WHEN max_seed_risk_score >= 51 THEN 'high' "
+        "SELECT npi, CASE WHEN max_seed_risk_score >= 30 THEN 'high' "
         "ELSE 'low' END AS band FROM provider_features LIMIT 10"
     )
     assert validate_sql(sql) == sql


### PR DESCRIPTION
## Summary
- Remove `asyncio.gather` deadlock on single psycopg connection in dashboard endpoint
- Add graceful fallback for missing `case_actions` table in cases endpoint  
- Recalibrate risk bands: **stable 0-25, review 26-50, high_risk 51+**
- Replace all hardcoded threshold values with taxonomy constants (22 files)
- Update AI prompts few-shot examples to use dynamic thresholds

## Risk Band Distribution (33,825 providers)
| Band | Count | % |
|---|---|---|
| stable | 28,486 | 84.2% |
| review | 4,494 | 13.3% |
| high_risk | 845 | 2.5% |

Closes #452