### PR TITLE
fix(test): update Dashboard KPI assertion to match pending_count mock (#459)

### DIFF
--- a/frontend/src/pages/__tests__/Dashboard.test.tsx
+++ b/frontend/src/pages/__tests__/Dashboard.test.tsx
@@ -103,8 +103,8 @@ describe("Dashboard", () => {
     expect(screen.getByText("5,678")).toBeInTheDocument();
     // "50" appears in both KPI card and Risk Distribution
     expect(screen.getAllByText("50").length).toBeGreaterThanOrEqual(1);
-    // Pending Review count equals pending.length = 1
-    expect(screen.getByText("1")).toBeInTheDocument();
+    // Pending Review count comes from stats.pending_count = 42
+    expect(screen.getByText("42")).toBeInTheDocument();
   });
 
   it("renders all four KPI card labels", async () => {


### PR DESCRIPTION
Closes #459

The KPI card 'renders KPI cards' test was asserting `getByText("1")` — a leftover from when the Pending Review count was derived from `pending.length`. PR #454 added `pending_count: 42` to `mockStats` but didn't update the assertion. Updated to `getByText("42")` to match the mock.