### PR TITLE
fix(api): make live queue startup non-blocking (#461)

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
+import logging
 import os
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 
 from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -12,6 +14,40 @@ from src.api.auth import get_current_user
 from src.api.deps import close_pool, open_pool
 from src.api.graph_client import close_neo4j, open_neo4j
 from src.api.live_queue import start_queue, stop_queue
+
+logger = logging.getLogger(__name__)
+
+
+async def _start_live_queue_background() -> None:
+    """Start the live queue after app startup without blocking readiness."""
+    try:
+        await start_queue()
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        logger.exception("Live queue startup failed")
+
+
+def _schedule_live_queue_startup(app: FastAPI) -> asyncio.Task[None]:
+    """Create and store the background task responsible for live queue startup."""
+    task = asyncio.create_task(_start_live_queue_background())
+    app.state.live_queue_task = task
+    return task
+
+
+async def _shutdown_live_queue_startup(task: asyncio.Task[None] | None) -> None:
+    """Cancel or drain the background startup task during shutdown."""
+    if task is None:
+        return
+
+    if not task.done():
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+        return
+
+    with suppress(asyncio.CancelledError):
+        task.result()
 
 
 @asynccontextmanager
@@ -22,11 +58,15 @@ async def lifespan(app: FastAPI):
         await open_neo4j()
     except Exception:
         pass  # Neo4j is optional — API works without it
-    await start_queue()
-    yield
-    await stop_queue()
-    await close_neo4j()
-    await close_pool()
+
+    live_queue_task = _schedule_live_queue_startup(app)
+    try:
+        yield
+    finally:
+        await _shutdown_live_queue_startup(live_queue_task)
+        await stop_queue()
+        await close_neo4j()
+        await close_pool()
 
 
 def create_app() -> FastAPI:

--- a/src/api/live_queue.py
+++ b/src/api/live_queue.py
@@ -498,7 +498,25 @@ class QueueManager:
                 logger.warning("live queue: already running")
                 return
             self.running = True
-            await self.build_queue()
+            self.ready = False
+            try:
+                await self.build_queue()
+            except asyncio.CancelledError:
+                self.running = False
+                self.ready = False
+                self.queue = []
+                self.position = 0
+                self.queue_actual_counts = {}
+                logger.info("live queue: startup cancelled")
+                raise
+            except Exception:
+                self.running = False
+                self.ready = False
+                self.queue = []
+                self.position = 0
+                self.queue_actual_counts = {}
+                logger.exception("live queue: startup failed")
+                raise
             self._task = asyncio.create_task(self._emit_loop())
             logger.info("live queue: started")
 
@@ -506,6 +524,7 @@ class QueueManager:
         """Stop the emit loop."""
         async with self._lock:
             self.running = False
+            self.ready = False
             if self._task:
                 self._task.cancel()
                 try:

--- a/tests/test_app_lifespan.py
+++ b/tests/test_app_lifespan.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
+from asyncio import Future
 from contextlib import asynccontextmanager
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
 import pytest
@@ -29,6 +31,8 @@ _LIFESPAN_PATCHES = {
     "src.api.app.close_pool": AsyncMock(),
     "src.api.app.open_neo4j": AsyncMock(),
     "src.api.app.close_neo4j": AsyncMock(),
+    "src.api.app.stop_queue": AsyncMock(),
+    "src.api.app._shutdown_live_queue_startup": AsyncMock(),
 }
 
 
@@ -179,6 +183,8 @@ async def test_lifespan_neo4j_failure_does_not_block_startup() -> None:
 
     mock_open_pool = AsyncMock()
     mock_open_neo4j = AsyncMock(side_effect=ConnectionRefusedError("Neo4j down"))
+    mock_schedule_live_queue = Mock(return_value=Future())
+    mock_schedule_live_queue.return_value.set_result(None)
     mock_app = AsyncMock()
 
     with (
@@ -186,23 +192,32 @@ async def test_lifespan_neo4j_failure_does_not_block_startup() -> None:
         patch("src.api.app.close_pool", AsyncMock()),
         patch("src.api.app.open_neo4j", mock_open_neo4j),
         patch("src.api.app.close_neo4j", AsyncMock()),
+        patch("src.api.app.stop_queue", AsyncMock()),
+        patch("src.api.app._schedule_live_queue_startup", mock_schedule_live_queue),
+        patch("src.api.app._shutdown_live_queue_startup", AsyncMock()),
     ):
         async with lifespan(mock_app):
             pass  # startup succeeded despite Neo4j failure
 
     mock_open_pool.assert_awaited_once()
     mock_open_neo4j.assert_awaited_once()
+    mock_schedule_live_queue.assert_called_once_with(mock_app)
 
 
 @pytest.mark.asyncio
 async def test_lifespan_calls_open_and_close() -> None:
-    """Lifespan opens pool/neo4j on startup and closes on shutdown."""
+    """Lifespan opens dependencies, schedules queue startup, and closes cleanly."""
     from src.api.app import lifespan
 
     mock_open = AsyncMock()
     mock_close = AsyncMock()
     mock_neo_open = AsyncMock()
     mock_neo_close = AsyncMock()
+    mock_stop_queue = AsyncMock()
+    mock_shutdown_live_queue = AsyncMock()
+    mock_task = Future()
+    mock_task.set_result(None)
+    mock_schedule_live_queue = Mock(return_value=mock_task)
     mock_app = AsyncMock()
 
     with (
@@ -210,6 +225,9 @@ async def test_lifespan_calls_open_and_close() -> None:
         patch("src.api.app.close_pool", mock_close),
         patch("src.api.app.open_neo4j", mock_neo_open),
         patch("src.api.app.close_neo4j", mock_neo_close),
+        patch("src.api.app.stop_queue", mock_stop_queue),
+        patch("src.api.app._schedule_live_queue_startup", mock_schedule_live_queue),
+        patch("src.api.app._shutdown_live_queue_startup", mock_shutdown_live_queue),
     ):
         async with lifespan(mock_app):
             pass
@@ -218,3 +236,18 @@ async def test_lifespan_calls_open_and_close() -> None:
     mock_close.assert_awaited_once()
     mock_neo_open.assert_awaited_once()
     mock_neo_close.assert_awaited_once()
+    mock_schedule_live_queue.assert_called_once_with(mock_app)
+    mock_shutdown_live_queue.assert_awaited_once_with(mock_task)
+    mock_stop_queue.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_live_queue_startup_cancels_pending_task() -> None:
+    """Pending live queue startup tasks are cancelled during shutdown."""
+    from src.api.app import _shutdown_live_queue_startup
+
+    task = asyncio.create_task(asyncio.sleep(60))
+
+    await _shutdown_live_queue_startup(task)
+
+    assert task.cancelled()

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -9,7 +9,7 @@ import pytest
 from fastapi import FastAPI
 
 from src.api.live_queue import QueueEvent, QueueManager
-from src.api.routes.live import router
+from src.api.routes.live import router, stream_claims
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -167,10 +167,8 @@ async def test_tps_endpoint(app, queue_mgr):
 @pytest.mark.asyncio
 async def test_stream_returns_sse_content_type(app, queue_mgr):
     with patch("src.api.routes.live.queue_manager", queue_mgr):
-        async with httpx.AsyncClient(
-            transport=httpx.ASGITransport(app=app),
-            base_url="http://test",
-        ) as client:
-            async with client.stream("GET", "/api/live/stream") as resp:
-                assert resp.status_code == 200
-                assert "text/event-stream" in resp.headers["content-type"]
+        resp = await stream_claims(0.0)
+        assert resp.media_type == "text/event-stream"
+        assert resp.headers["Cache-Control"] == "no-cache"
+        assert resp.headers["Connection"] == "keep-alive"
+        assert resp.headers["X-Accel-Buffering"] == "no"


### PR DESCRIPTION
## Summary

Closes #461

Hotfix for API rollout instability: FastAPI startup no longer blocks on building the persistent live queue.

## Root cause

The app lifespan awaited  before yielding.  builds the full 10K live queue before returning, which delayed startup long enough for Kubernetes readiness/liveness probes to fail. New API pods stayed in , never exposed , and flapped during rollout.

## Changes

- schedule live queue startup in a background task after app startup
- keep shutdown safe if the queue startup task is still running or gets cancelled
- harden  so cancellation/failure resets state cleanly
- make  deterministic and non-hanging by removing the infinite SSE stream client usage
- update lifespan tests to cover background scheduling and shutdown behavior

## Local validation

- 
==================================== ERRORS ====================================
_____________________ ERROR collecting tests/test_live.py ______________________
ImportError while importing test module '/home/dev/Work/Precise/cms-fraud-detection/tests/test_live.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../../.pyenv/versions/3.13.0/lib/python3.13/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests/test_live.py:11: in <module>
    from src.api.live_queue import QueueEvent, QueueManager
src/api/live_queue.py:28: in <module>
    from psycopg.rows import dict_row
E   ModuleNotFoundError: No module named 'psycopg'
=========================== short test summary info ============================
ERROR tests/test_live.py
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
1 error in 0.33s
- 
==================================== ERRORS ====================================
_____________________ ERROR collecting tests/test_cases.py _____________________
ImportError while importing test module '/home/dev/Work/Precise/cms-fraud-detection/tests/test_cases.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../../.pyenv/versions/3.13.0/lib/python3.13/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests/test_cases.py:9: in <module>
    from src.api.routes.cases import list_actions, list_pending, record_action
src/api/routes/cases.py:13: in <module>
    from psycopg import AsyncConnection
E   ModuleNotFoundError: No module named 'psycopg'
_____________________ ERROR collecting tests/test_live.py ______________________
ImportError while importing test module '/home/dev/Work/Precise/cms-fraud-detection/tests/test_live.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../../.pyenv/versions/3.13.0/lib/python3.13/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests/test_live.py:11: in <module>
    from src.api.live_queue import QueueEvent, QueueManager
src/api/live_queue.py:28: in <module>
    from psycopg.rows import dict_row
E   ModuleNotFoundError: No module named 'psycopg'
=========================== short test summary info ============================
ERROR tests/test_cases.py
ERROR tests/test_live.py
!!!!!!!!!!!!!!!!!!! Interrupted: 2 errors during collection !!!!!!!!!!!!!!!!!!!!
2 errors in 0.35s
- 

## Operational impact

This should let  come up immediately during pod boot while the live queue finishes building in the background, which should stop the API rollout flapping seen in Kubernetes.