### PR TITLE
fix(api): offload live queue scoring to thread pool (#463)

### DIFF
--- a/k8s/cms-fraud/api.yaml
+++ b/k8s/cms-fraud/api.yaml
@@ -39,23 +39,26 @@ spec:
                   key: NEO4J_PASSWORD
           readinessProbe:
             httpGet:
-              path: /health
+              path: /healthz
               port: 8000
             initialDelaySeconds: 5
+            timeoutSeconds: 3
             periodSeconds: 10
           livenessProbe:
             httpGet:
-              path: /health
+              path: /healthz
               port: 8000
-            initialDelaySeconds: 15
+            initialDelaySeconds: 30
+            timeoutSeconds: 3
             periodSeconds: 30
+            failureThreshold: 5
           resources:
             requests:
-              cpu: 250m
-              memory: 256Mi
-            limits:
-              cpu: "1"
+              cpu: 500m
               memory: 512Mi
+            limits:
+              cpu: "2"
+              memory: 1Gi
 ---
 apiVersion: v1
 kind: Service

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -139,8 +139,13 @@ def create_app() -> FastAPI:
 
     app.include_router(live_router, prefix="/api")
 
-    # --- Health endpoint (no router needed) ---
+    # --- Health endpoints ---
     from src.api.schemas import HealthResponse
+
+    @app.get("/healthz", tags=["ops"])
+    async def healthz():
+        """Lightweight probe endpoint — no DB/Neo4j, <1 ms."""
+        return {"status": "ok"}
 
     @app.get("/health", response_model=HealthResponse, tags=["ops"])
     async def health():

--- a/src/api/live_queue.py
+++ b/src/api/live_queue.py
@@ -265,9 +265,13 @@ class QueueManager:
                     feat = await cur.fetchone()
                     npi_features_cache[npi] = dict(feat) if feat else None
 
-            for row in all_candidates:
-                evt = self._score_row(dict(row), npi_features_cache)
-                scored_by_label[evt.case_label].append(evt)
+            # Offload CPU-bound scoring to a thread so the event loop
+            # stays responsive for health probes and other requests.
+            scored_by_label = await asyncio.to_thread(
+                self._score_all,
+                all_candidates,
+                npi_features_cache,
+            )
 
             logger.info(
                 "live queue: scored — high_risk=%d, review=%d, stable=%d",
@@ -323,6 +327,18 @@ class QueueManager:
             await cur.execute(sql, params)
             rows = await cur.fetchall()
         return [dict(r) for r in rows]
+
+    @staticmethod
+    def _score_all(
+        candidates: list[dict],
+        features_cache: dict[str, dict | None],
+    ) -> dict[str, list[QueueEvent]]:
+        """Score all candidates (CPU-bound). Designed to run in a thread."""
+        scored: dict[str, list[QueueEvent]] = defaultdict(list)
+        for row in candidates:
+            evt = QueueManager._score_row(dict(row), features_cache)
+            scored[evt.case_label].append(evt)
+        return scored
 
     @staticmethod
     def _score_row(

--- a/tests/test_app_lifespan.py
+++ b/tests/test_app_lifespan.py
@@ -64,18 +64,36 @@ def test_all_api_routes_have_prefix() -> None:
 
     app = create_app()
     framework_paths = {"/openapi.json", "/docs", "/docs/oauth2-redirect", "/redoc"}
+    ops_paths = {"/health", "/healthz"}
     paths = [
         r.path
         for r in app.routes
-        if hasattr(r, "path") and r.path not in framework_paths and r.path != "/health"
+        if hasattr(r, "path") and r.path not in framework_paths and r.path not in ops_paths
     ]
     for path in paths:
         assert path.startswith("/api"), f"Route {path} does not start with /api"
 
 
 # ---------------------------------------------------------------------------
-# Health endpoint
+# Health endpoints
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_healthz_returns_ok_immediately() -> None:
+    """Lightweight /healthz responds instantly with no dependencies."""
+    with patch.multiple(
+        "src.api.app", **{k.split(".")[-1]: AsyncMock() for k in _LIFESPAN_PATCHES}
+    ):
+        from src.api.app import create_app
+
+        app = create_app()
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/healthz")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

The live queue `build_queue()` runs CPU-bound ML scoring (`score_case()` + `score_provider()`) for thousands of candidates **directly on the asyncio event loop**. This completely starves all HTTP handlers — even `/docs` and `/openapi.json` time out. Health probes fail → pods never become ready → liveness kills them → restart loop.

**Evidence from investigation:**
- TCP connect succeeds but `/health` hangs for 30+ seconds inside the pod
- `/docs` (zero DB) also times out — confirming event loop starvation, not DB issue
- DB is fine: direct `SELECT 1` returns in 0.02s
- `provider_service_cases` has 500K rows, 33,825 unique NPIs

## Changes

### 1. Offload scoring to thread (`live_queue.py`)
- New `_score_all()` static method encapsulates the CPU-bound scoring loop
- Called via `asyncio.to_thread()` so the event loop stays free for HTTP requests
- DB fetches remain async; only pure-Python + sklearn scoring moves to thread

### 2. Lightweight probe endpoint (`app.py`)
- New `GET /healthz` returns `{"status": "ok"}` immediately — no DB, no Neo4j
- `GET /health` remains as the deep-check endpoint for monitoring

### 3. K8s deployment hardening (`api.yaml`)
- Probes switched from `/health` → `/healthz`
- `livenessProbe.initialDelaySeconds`: 15 → 30
- Added `timeoutSeconds: 3` and `failureThreshold: 5`
- Resources bumped: cpu 1→2, memory 512Mi→1Gi (ML scoring needs room)

## Testing

- 66 backend tests pass including new `test_healthz_returns_ok_immediately`
- Ruff lint + format clean

Closes #463