### PR TITLE
feat: restore live monitor to sidebar

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -2,6 +2,7 @@ import React, { Suspense } from "react";
 import { NavLink, Outlet } from "react-router-dom";
 import {
   LayoutDashboard,
+  Activity,
   Users,
   FileText,
   BriefcaseBusiness,
@@ -26,6 +27,7 @@ interface NavItem {
 
 const navigation: NavItem[] = [
   { name: "Dashboard", href: "/", icon: LayoutDashboard },
+  { name: "Live Monitor", href: "/live", icon: Activity },
   { name: "Providers", href: "/providers", icon: Users },
   { name: "Claims", href: "/claims", icon: FileText },
   { name: "Investigations", href: "/investigations", icon: BriefcaseBusiness },

--- a/frontend/src/components/__tests__/Layout.test.tsx
+++ b/frontend/src/components/__tests__/Layout.test.tsx
@@ -58,6 +58,7 @@ describe("Layout", () => {
 
     expect(labels).toEqual([
       "Dashboard",
+      "Live Monitor",
       "Providers",
       "Claims",
       "Investigations",
@@ -66,7 +67,6 @@ describe("Layout", () => {
       "Simulate",
       "Fairness",
     ]);
-    expect(within(nav).queryByRole("link", { name: "Live Monitor" })).not.toBeInTheDocument();
     expect(within(nav).queryByRole("link", { name: "Data" })).not.toBeInTheDocument();
   });
 
@@ -93,6 +93,7 @@ describe("Layout", () => {
 
     expect(labels).toEqual([
       "Dashboard",
+      "Live Monitor",
       "Providers",
       "Claims",
       "Investigations",


### PR DESCRIPTION
## Summary
- restore Live Monitor to the primary sidebar navigation
- place it immediately after Dashboard to match the historical product layout
- update the layout test expectations for analyst and admin users

## Testing
- npm --prefix frontend test -- src/components/__tests__/Layout.test.tsx